### PR TITLE
Conflicting Car Accessibility Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -348,6 +348,8 @@
   },
   "ConflictingCarAccessibilityCheck": {
     "enabled": true,
+    "overriding.filter":["bus", "minibus", "motorcycle", "psv", "public_transportation", "good", "hsv", "agricultural",
+      "snowmobile", "hov", "emergency", "disabled"],
     "challenge": {
       "description": "This task contains roads with conflicting highway and transportation tags",
       "blurb": "Conflicting highway and transportation tags",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -69,14 +69,14 @@
       "difficulty": "EASY"
     }
   },
-  "DuplicatePointCheck": {
-    "challenge": {
-      "description": "Tasks contain node locations where duplicate points of interest are found.",
-      "blurb": "Duplicate Points",
-      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-      "difficulty": "EASY"
-    }
-  },
+   "DuplicatePointCheck": {
+     "challenge": {
+       "description": "Tasks contain node locations where duplicate points of interest are found.",
+       "blurb": "Duplicate Points",
+       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+       "difficulty": "EASY"
+     }
+   },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -348,8 +348,8 @@
   },
   "ConflictingCarAccessibilityCheck": {
     "enabled": true,
-    "overriding.filter":["bus", "minibus", "motorcycle", "psv", "public_transportation", "good", "hsv", "agricultural",
-      "snowmobile", "hov", "emergency", "disabled"],
+    "accessibility.overriding.tags":["bus", "minibus", "motorcycle", "psv", "public_transportation", "good", "hsv", "agricultural",
+      "snowmobile", "hov", "emergency", "disabled", "hazmat"],
     "challenge": {
       "description": "This task contains roads with conflicting highway and transportation tags",
       "blurb": "Conflicting highway and transportation tags",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -496,25 +496,11 @@
     }
   },
   "ConflictingCarAccessibilityCheck": {
-    "accessibility.overriding.tags": [
-      "bus",
-      "minibus",
-      "motorcycle",
-      "psv",
-      "public_transportation",
-      "good",
-      "hsv",
-      "agricultural",
-      "snowmobile",
-      "hov",
-      "emergency",
-      "disabled",
-      "hazmat"
-    ],
+    "accessibility.overriding.tags": "bus->yes|minibus->yes|motorcycle->yes|taxi->yes|tourist_bus->yes|share_taxi->yes|psv->yes|good->yes|hsv->yes|agricultural->yes|snowmobile->yes|hov->yes|public_transportation->yes|emergency->yes|disabled->yes|hazmat->yes",
     "challenge": {
-      "description": "This task contains roads with conflicting highway and transportation tags",
-      "blurb": "Conflicting highway and transportation tags",
-      "instruction": "Open your favorite editor and examine if there is conflict in combination of highway tag and transportation tag.",
+      "description": "This task contains roads with conflicting highway, access and transportation tags",
+      "blurb": "Conflicting highway, access and transportation tags",
+      "instruction": "Open your favorite editor and examine if there is conflict in combination of highway tag, access tag and transportation tag.",
       "difficulty": "NORMAL",
       "tags": "highway"
     }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -345,5 +345,16 @@
       "difficulty": "NORMAL",
       "defaultPriority": "MEDIUM"
     }
+  },
+  "ConflictingCarAccessibilityCheck": {
+    "enabled": true,
+    "challenge": {
+      "description": "This task contains roads with conflicting highway and transportation tags",
+      "blurb": "Roads with conflicting car access tags",
+      "instruction": "Open your favorite editor and examine if there is conflict in highway tags.",
+      "difficulty": "NORMAL",
+      "tags":"highway"
+    }
+
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -13,6 +13,7 @@
     }
   },
   "OrphanNodeCheck": {
+
   },
   "AddressPointMatchCheck": {
     "bounds.size": 150.0,
@@ -24,14 +25,14 @@
       "defaultPriority": "LOW"
     }
   },
-  "AreasWithHighwayTagCheck": {
-    "tag.filters": "highway->!pedestrian&area->!yes",
-    "challenge": {
-      "description": "A Highway should never be tagged as an area, all these tasks involve highways that have been.",
-      "blurb": "Highways should not be tagged as Areas.",
-      "instruction": "Remove highway tag from feature with area tag.",
-      "difficulty": "EASY",
-      "tags": "highway,landuse"
+  "AreasWithHighwayTagCheck":{
+    "tag.filters":"highway->!pedestrian&area->!yes",
+    "challenge":{
+      "description":"A Highway should never be tagged as an area, all these tasks involve highways that have been.",
+      "blurb":"Highways should not be tagged as Areas.",
+      "instruction":"Remove highway tag from feature with area tag.",
+      "difficulty":"EASY",
+      "tags":"highway,landuse"
     }
   },
   "BuildingRoadIntersectionCheck": {
@@ -42,24 +43,14 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "building,highway"
+      "tags":"building,highway"
     }
   },
   "ConflictingAreaTagCombination": {
@@ -114,55 +105,46 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
-  "IntersectingBuildingsCheck": {
+  "IntersectingBuildingsCheck":
+  {
     "intersection.lower.limit": 0.01,
     "challenge": {
       "description": "Buildings that intersect, contain, or overlap each other.",
       "blurb": "Intersecting Buildings",
       "instruction": "Correct intersecting buildings by moving them or dissolving one into another.",
       "difficulty": "NORMAL",
-      "tags": "building"
+      "tags":"building"
     }
   },
-  "InvalidAccessTagCheck": {
-    "tags.filter": "public_transport->!yes&psv->!yes&bus->!yes&emergency->!yes&motor_vehicle->!no&vehicle->!no&motorcar->!no",
-    "minimum.highway.type": "residential",
+  "InvalidAccessTagCheck":{
+    "tags.filter":"public_transport->!yes&psv->!yes&bus->!yes&emergency->!yes&motor_vehicle->!no&vehicle->!no&motorcar->!no",
+    "minimum.highway.type":"residential",
     "challenge": {
       "description": "Tasks containing invalid access tags",
       "blurb": "Invalid Access Tags",
       "instruction": "Correct the displayed invalid access=no tag.",
       "difficulty": "NORMAL",
-      "tags": "access,highway"
+      "tags":"access,highway"
     }
   },
   "InvalidLanesTagCheck": {
     "lanes.filter": "Lanes->1,1.5,2,3,4,5,6,7,8,9,10",
-    "challenge": {
-      "description": "Tasks contain invalid values for the lanes tag.",
-      "blurb": "Invalid Lanes Tags",
-      "instruction": "Change the lanes tag to have a valid and representative value.",
-      "difficulty": "EASY",
-      "tags": "lanes,highway"
+    "challenge":{
+      "description":"Tasks contain invalid values for the lanes tag.",
+      "blurb":"Invalid Lanes Tags",
+      "instruction":"Change the lanes tag to have a valid and representative value.",
+      "difficulty":"EASY",
+      "tags":"lanes,highway"
     }
   },
   "InvalidTurnRestrictionCheck": {
@@ -171,88 +153,17 @@
       "blurb": "Invalid Turn Restrictions",
       "instruction": "Correct the displayed invalid turn restriction",
       "difficulty": "HARD",
-      "tags": "highway"
+      "tags":"highway"
     }
   },
-  "MalformedRoundaboutCheck": {
-    "traffic.countries.left": [
-      "AIA",
-      "ATG",
-      "AUS",
-      "BGD",
-      "BHS",
-      "BMU",
-      "BRB",
-      "BRN",
-      "BTN",
-      "BWA",
-      "CCK",
-      "COK",
-      "CXR",
-      "CYM",
-      "CYP",
-      "DMA",
-      "FJI",
-      "FLK",
-      "GBR",
-      "GGY",
-      "GRD",
-      "GUY",
-      "HKG",
-      "IDN",
-      "IMN",
-      "IND",
-      "IRL",
-      "JAM",
-      "JEY",
-      "JPN",
-      "KEN",
-      "KIR",
-      "KNA",
-      "LCA",
-      "LKA",
-      "LSO",
-      "MAC",
-      "MDV",
-      "MLT",
-      "MOZ",
-      "MSR",
-      "MUS",
-      "MWI",
-      "MYS",
-      "NAM",
-      "NFK",
-      "NIU",
-      "NPL",
-      "NRU",
-      "NZL",
-      "PAK",
-      "PCN",
-      "PNG",
-      "SGP",
-      "SGS",
-      "SHN",
-      "SLB",
-      "SUR",
-      "SWZ",
-      "SYC",
-      "TCA",
-      "THA",
-      "TKL",
-      "TLS",
-      "TON",
-      "TTO",
-      "TUV",
-      "TZA",
-      "UGA",
-      "VCT",
-      "VGB",
-      "VIR",
-      "WSM",
-      "ZAF",
-      "ZMB",
-      "ZWE"
-    ],
+  "MalformedRoundaboutCheck" : {
+    "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
+      "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
+      "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",
+      "KNA", "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ", "MSR", "MUS", "MWI",
+      "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN", "PNG", "SGP",
+      "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS", "TON",
+      "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE"],
     "challenge": {
       "description": "Tasks contain roundabouts that are malformed.",
       "blurb": "Malformed roundabouts",
@@ -268,22 +179,15 @@
       "difficulty": "HARD"
     }
   },
-  "OverlappingAOIPolygonCheck": {
-    "aoi.tags.filters": [
-      "amenity->FESTIVAL_GROUNDS",
-      "amenity->GRAVE_YARD|landuse->CEMETERY",
+  "OverlappingAOIPolygonCheck":{
+    "aoi.tags.filters": ["amenity->FESTIVAL_GROUNDS", "amenity->GRAVE_YARD|landuse->CEMETERY",
       "boundary->NATIONAL_PARK,PROTECTED_AREA|leisure->NATURE_RESERVE,PARK",
-      "historic->BATTLEFIELD",
-      "landuse->FOREST|natural->WOOD",
+      "historic->BATTLEFIELD", "landuse->FOREST|natural->WOOD",
       "landuse->RECREATION_GROUND|leisure->RECREATION_GROUND",
-      "landuse->VILLAGE_GREEN|leisure->PARK",
-      "leisure->GARDEN",
-      "leisure->GOLF_COURSE|sport->GOLF",
-      "leisure->PARK&name->*",
-      "natural->BEACH",
-      "tourism->ZOO"
-    ],
-    "intersect.minimum.limit": 0.01,
+      "landuse->VILLAGE_GREEN|leisure->PARK", "leisure->GARDEN",
+      "leisure->GOLF_COURSE|sport->GOLF", "leisure->PARK&name->*", "natural->BEACH",
+      "tourism->ZOO"],
+    "intersect.minimum.limit":0.01,
     "challenge": {
       "description": "Tasks containing overlapping AOI ways",
       "blurb": "Overlapping AOI Polygon",
@@ -299,24 +203,14 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "RoundaboutValenceCheck": {
@@ -330,7 +224,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter": "highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
+    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",
@@ -338,24 +232,14 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "SharpAngleCheck": {
@@ -367,24 +251,14 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "SinkIslandCheck": {
@@ -396,38 +270,24 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "StreetNameIntegersOnlyCheck": {
-    "name.keys.filter": [
-      "name",
-      "name:left",
-      "name:right"
-    ],
+    "name.keys.filter":["name","name:left","name:right"],
     "challenge": {
       "description": "Tasks containing name tags with only integers",
       "blurb": "Street Names Integers Only",
       "instruction": "Correct the road with only integers for names.",
       "difficulty": "Medium",
-      "tags": "highway,name"
+      "tags":"highway,name"
     }
   },
   "SnakeRoadCheck": {
@@ -438,48 +298,39 @@
       "difficulty": "MEDIUM",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=motorway",
-          "highway=motorway_link",
-          "highway=trunk",
-          "highway=trunk_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
       },
       "mediumPriorityRule": {
-        "condition": "OR",
-        "rules": [
-          "highway=primary",
-          "highway=primary_link",
-          "highway=secondary",
-          "highway=secondary_link"
-        ]
+        "condition":"OR",
+        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
       },
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "SignPostCheck": {
     "linkLength": {
       "minimum.meters": 50.0
     },
-    "ramp": {
-      "max.edges": 10,
-      "filter": "highway->motorway_link,trunk_link"
+    "ramp":
+    {
+      "max.edges":10,
+      "filter":"highway->motorway_link,trunk_link"
     },
-    "source.filter": "highway->motorway,trunk",
-    "destination_tag.filter": "destination->*|destination:ref->*|destination:street->*",
-    "arterial.minimum": "RESIDENTIAL",
+    "source.filter":"highway->motorway,trunk",
+    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
+    "arterial.minimum":"RESIDENTIAL",
     "challenge": {
       "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
       "blurb": "Missing sign post tags",
       "instruction": "Either add the missing motorway_junction tag to the identified node and / or the destination tag to the exiting link segment.",
       "difficulty": "NORMAL",
       "defaultPriority": "MEDIUM",
-      "tags": "highway"
+      "tags":"highway"
     }
   },
   "WaterbodyAndIslandSizeCheck": {
-    "surface": {
+    "surface":{
       "waterbody.minimum.meters": 10.0,
       "waterbody.maximum.kilometers": 370000.0,
       "island.minimum.meters": 10.0,

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -350,8 +350,8 @@
     "enabled": true,
     "challenge": {
       "description": "This task contains roads with conflicting highway and transportation tags",
-      "blurb": "Roads with conflicting car access tags",
-      "instruction": "Open your favorite editor and examine if there is conflict in highway tags.",
+      "blurb": "Conflicting highway and transportation tags",
+      "instruction": "Open your favorite editor and examine if there is conflict in combination of highway tag and transportation tag.",
       "difficulty": "NORMAL",
       "tags":"highway"
     }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -13,7 +13,6 @@
     }
   },
   "OrphanNodeCheck": {
-
   },
   "AddressPointMatchCheck": {
     "bounds.size": 150.0,
@@ -25,14 +24,14 @@
       "defaultPriority": "LOW"
     }
   },
-  "AreasWithHighwayTagCheck":{
-    "tag.filters":"highway->!pedestrian&area->!yes",
-    "challenge":{
-      "description":"A Highway should never be tagged as an area, all these tasks involve highways that have been.",
-      "blurb":"Highways should not be tagged as Areas.",
-      "instruction":"Remove highway tag from feature with area tag.",
-      "difficulty":"EASY",
-      "tags":"highway,landuse"
+  "AreasWithHighwayTagCheck": {
+    "tag.filters": "highway->!pedestrian&area->!yes",
+    "challenge": {
+      "description": "A Highway should never be tagged as an area, all these tasks involve highways that have been.",
+      "blurb": "Highways should not be tagged as Areas.",
+      "instruction": "Remove highway tag from feature with area tag.",
+      "difficulty": "EASY",
+      "tags": "highway,landuse"
     }
   },
   "BuildingRoadIntersectionCheck": {
@@ -43,14 +42,24 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"building,highway"
+      "tags": "building,highway"
     }
   },
   "ConflictingAreaTagCombination": {
@@ -69,14 +78,14 @@
       "difficulty": "EASY"
     }
   },
-   "DuplicatePointCheck": {
-     "challenge": {
-       "description": "Tasks contain node locations where duplicate points of interest are found.",
-       "blurb": "Duplicate Points",
-       "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
-       "difficulty": "EASY"
-     }
-   },
+  "DuplicatePointCheck": {
+    "challenge": {
+      "description": "Tasks contain node locations where duplicate points of interest are found.",
+      "blurb": "Duplicate Points",
+      "instruction": "Open your favorite editor and remove one or more of the duplicate points of interest until only one remains.",
+      "difficulty": "EASY"
+    }
+  },
   "DuplicateWaysCheck": {
     "challenge": {
       "description": "Tasks contain Ways which have been partially or completely duplicated.",
@@ -105,46 +114,55 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
-  "IntersectingBuildingsCheck":
-  {
+  "IntersectingBuildingsCheck": {
     "intersection.lower.limit": 0.01,
     "challenge": {
       "description": "Buildings that intersect, contain, or overlap each other.",
       "blurb": "Intersecting Buildings",
       "instruction": "Correct intersecting buildings by moving them or dissolving one into another.",
       "difficulty": "NORMAL",
-      "tags":"building"
+      "tags": "building"
     }
   },
-  "InvalidAccessTagCheck":{
-    "tags.filter":"public_transport->!yes&psv->!yes&bus->!yes&emergency->!yes&motor_vehicle->!no&vehicle->!no&motorcar->!no",
-    "minimum.highway.type":"residential",
+  "InvalidAccessTagCheck": {
+    "tags.filter": "public_transport->!yes&psv->!yes&bus->!yes&emergency->!yes&motor_vehicle->!no&vehicle->!no&motorcar->!no",
+    "minimum.highway.type": "residential",
     "challenge": {
       "description": "Tasks containing invalid access tags",
       "blurb": "Invalid Access Tags",
       "instruction": "Correct the displayed invalid access=no tag.",
       "difficulty": "NORMAL",
-      "tags":"access,highway"
+      "tags": "access,highway"
     }
   },
   "InvalidLanesTagCheck": {
     "lanes.filter": "Lanes->1,1.5,2,3,4,5,6,7,8,9,10",
-    "challenge":{
-      "description":"Tasks contain invalid values for the lanes tag.",
-      "blurb":"Invalid Lanes Tags",
-      "instruction":"Change the lanes tag to have a valid and representative value.",
-      "difficulty":"EASY",
-      "tags":"lanes,highway"
+    "challenge": {
+      "description": "Tasks contain invalid values for the lanes tag.",
+      "blurb": "Invalid Lanes Tags",
+      "instruction": "Change the lanes tag to have a valid and representative value.",
+      "difficulty": "EASY",
+      "tags": "lanes,highway"
     }
   },
   "InvalidTurnRestrictionCheck": {
@@ -153,17 +171,88 @@
       "blurb": "Invalid Turn Restrictions",
       "instruction": "Correct the displayed invalid turn restriction",
       "difficulty": "HARD",
-      "tags":"highway"
+      "tags": "highway"
     }
   },
-  "MalformedRoundaboutCheck" : {
-    "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
-      "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
-      "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",
-      "KNA", "LCA", "LKA", "LSO", "MAC", "MDV", "MLT", "MOZ", "MSR", "MUS", "MWI",
-      "MYS", "NAM", "NFK", "NIU", "NPL", "NRU", "NZL", "PAK", "PCN", "PNG", "SGP",
-      "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA", "TKL", "TLS", "TON",
-      "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF", "ZMB", "ZWE"],
+  "MalformedRoundaboutCheck": {
+    "traffic.countries.left": [
+      "AIA",
+      "ATG",
+      "AUS",
+      "BGD",
+      "BHS",
+      "BMU",
+      "BRB",
+      "BRN",
+      "BTN",
+      "BWA",
+      "CCK",
+      "COK",
+      "CXR",
+      "CYM",
+      "CYP",
+      "DMA",
+      "FJI",
+      "FLK",
+      "GBR",
+      "GGY",
+      "GRD",
+      "GUY",
+      "HKG",
+      "IDN",
+      "IMN",
+      "IND",
+      "IRL",
+      "JAM",
+      "JEY",
+      "JPN",
+      "KEN",
+      "KIR",
+      "KNA",
+      "LCA",
+      "LKA",
+      "LSO",
+      "MAC",
+      "MDV",
+      "MLT",
+      "MOZ",
+      "MSR",
+      "MUS",
+      "MWI",
+      "MYS",
+      "NAM",
+      "NFK",
+      "NIU",
+      "NPL",
+      "NRU",
+      "NZL",
+      "PAK",
+      "PCN",
+      "PNG",
+      "SGP",
+      "SGS",
+      "SHN",
+      "SLB",
+      "SUR",
+      "SWZ",
+      "SYC",
+      "TCA",
+      "THA",
+      "TKL",
+      "TLS",
+      "TON",
+      "TTO",
+      "TUV",
+      "TZA",
+      "UGA",
+      "VCT",
+      "VGB",
+      "VIR",
+      "WSM",
+      "ZAF",
+      "ZMB",
+      "ZWE"
+    ],
     "challenge": {
       "description": "Tasks contain roundabouts that are malformed.",
       "blurb": "Malformed roundabouts",
@@ -179,15 +268,22 @@
       "difficulty": "HARD"
     }
   },
-  "OverlappingAOIPolygonCheck":{
-    "aoi.tags.filters": ["amenity->FESTIVAL_GROUNDS", "amenity->GRAVE_YARD|landuse->CEMETERY",
+  "OverlappingAOIPolygonCheck": {
+    "aoi.tags.filters": [
+      "amenity->FESTIVAL_GROUNDS",
+      "amenity->GRAVE_YARD|landuse->CEMETERY",
       "boundary->NATIONAL_PARK,PROTECTED_AREA|leisure->NATURE_RESERVE,PARK",
-      "historic->BATTLEFIELD", "landuse->FOREST|natural->WOOD",
+      "historic->BATTLEFIELD",
+      "landuse->FOREST|natural->WOOD",
       "landuse->RECREATION_GROUND|leisure->RECREATION_GROUND",
-      "landuse->VILLAGE_GREEN|leisure->PARK", "leisure->GARDEN",
-      "leisure->GOLF_COURSE|sport->GOLF", "leisure->PARK&name->*", "natural->BEACH",
-      "tourism->ZOO"],
-    "intersect.minimum.limit":0.01,
+      "landuse->VILLAGE_GREEN|leisure->PARK",
+      "leisure->GARDEN",
+      "leisure->GOLF_COURSE|sport->GOLF",
+      "leisure->PARK&name->*",
+      "natural->BEACH",
+      "tourism->ZOO"
+    ],
+    "intersect.minimum.limit": 0.01,
     "challenge": {
       "description": "Tasks containing overlapping AOI ways",
       "blurb": "Overlapping AOI Polygon",
@@ -203,14 +299,24 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "RoundaboutValenceCheck": {
@@ -224,7 +330,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
+    "tags.filter": "highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",
@@ -232,14 +338,24 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "SharpAngleCheck": {
@@ -251,14 +367,24 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "SinkIslandCheck": {
@@ -270,24 +396,38 @@
       "difficulty": "EASY",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "StreetNameIntegersOnlyCheck": {
-    "name.keys.filter":["name","name:left","name:right"],
+    "name.keys.filter": [
+      "name",
+      "name:left",
+      "name:right"
+    ],
     "challenge": {
       "description": "Tasks containing name tags with only integers",
       "blurb": "Street Names Integers Only",
       "instruction": "Correct the road with only integers for names.",
       "difficulty": "Medium",
-      "tags":"highway,name"
+      "tags": "highway,name"
     }
   },
   "SnakeRoadCheck": {
@@ -298,39 +438,48 @@
       "difficulty": "MEDIUM",
       "defaultPriority": "LOW",
       "highPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=motorway","highway=motorway_link","highway=trunk","highway=trunk_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=motorway",
+          "highway=motorway_link",
+          "highway=trunk",
+          "highway=trunk_link"
+        ]
       },
       "mediumPriorityRule": {
-        "condition":"OR",
-        "rules":["highway=primary","highway=primary_link","highway=secondary","highway=secondary_link"]
+        "condition": "OR",
+        "rules": [
+          "highway=primary",
+          "highway=primary_link",
+          "highway=secondary",
+          "highway=secondary_link"
+        ]
       },
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "SignPostCheck": {
     "linkLength": {
       "minimum.meters": 50.0
     },
-    "ramp":
-    {
-      "max.edges":10,
-      "filter":"highway->motorway_link,trunk_link"
+    "ramp": {
+      "max.edges": 10,
+      "filter": "highway->motorway_link,trunk_link"
     },
-    "source.filter":"highway->motorway,trunk",
-    "destination_tag.filter":"destination->*|destination:ref->*|destination:street->*",
-    "arterial.minimum":"RESIDENTIAL",
+    "source.filter": "highway->motorway,trunk",
+    "destination_tag.filter": "destination->*|destination:ref->*|destination:street->*",
+    "arterial.minimum": "RESIDENTIAL",
     "challenge": {
       "description": "Tasks contain nodes where sign post tagging could be missing.  In particular it looks for motorway and trunk ways which have a link edge exiting them.  A task is generated if either the connecting node is missing the motorway_junction tag or the exiting segment is missing the destination tag.",
       "blurb": "Missing sign post tags",
       "instruction": "Either add the missing motorway_junction tag to the identified node and / or the destination tag to the exiting link segment.",
       "difficulty": "NORMAL",
       "defaultPriority": "MEDIUM",
-      "tags":"highway"
+      "tags": "highway"
     }
   },
   "WaterbodyAndIslandSizeCheck": {
-    "surface":{
+    "surface": {
       "waterbody.minimum.meters": 10.0,
       "waterbody.maximum.kilometers": 370000.0,
       "island.minimum.meters": 10.0,
@@ -347,16 +496,27 @@
     }
   },
   "ConflictingCarAccessibilityCheck": {
-    "enabled": true,
-    "accessibility.overriding.tags":["bus", "minibus", "motorcycle", "psv", "public_transportation", "good", "hsv", "agricultural",
-      "snowmobile", "hov", "emergency", "disabled", "hazmat"],
+    "accessibility.overriding.tags": [
+      "bus",
+      "minibus",
+      "motorcycle",
+      "psv",
+      "public_transportation",
+      "good",
+      "hsv",
+      "agricultural",
+      "snowmobile",
+      "hov",
+      "emergency",
+      "disabled",
+      "hazmat"
+    ],
     "challenge": {
       "description": "This task contains roads with conflicting highway and transportation tags",
       "blurb": "Conflicting highway and transportation tags",
       "instruction": "Open your favorite editor and examine if there is conflict in combination of highway tag and transportation tag.",
       "difficulty": "NORMAL",
-      "tags":"highway"
+      "tags": "highway"
     }
-
   }
 }

--- a/docs/checks/conflictingCarAccessibilityCheck.md
+++ b/docs/checks/conflictingCarAccessibilityCheck.md
@@ -1,0 +1,93 @@
+# Conflicting Car Accessibility Check 
+
+This check flags roads that have conflicting highway and transportation tags. A conflict in these tags occurs when either of the two conditions is met:
+ * A car navigable highway tag value combined with a restrictive car 
+access tag value 
+ * A non-car navigable highway tag value combined with an open car access tag value
+#### Live Examples
+1. The way [id:369590090](https://www.openstreetmap.org/way/369590090) has conflicting values between `HighwayTag` (`highway`=`RESIDENTIAL`) and `VehicleTag`(`vehicle`=`NO`). This has `bicyle`=`DESIGNATED` and so the `Highway` tag should have been `highway=CYCLEWAY`.
+#### Code Review
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes & Relations; in our case, we’re are looking at [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:
+* Is an Edge
+* Has a `highway` tag
+* `AccessTag` for the object is not "no"
+* Has either `MotorVehicleTag` or `MotorcarTag` or `VehicleTag` and none of these are conditional tags
+* Is a master edge
+* Is not a way sectioned duplicate
+```java
+    @Override
+  @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Edge
+                && !AccessTag.isNo(object)
+                && ((object.getTag(MotorVehicleTag.KEY).isPresent()
+                        && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
+                        || (object.getTag(MotorcarTag.KEY).isPresent()
+                                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
+                        || (object.getTag(VehicleTag.KEY).isPresent())
+                                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
+                && ((Edge) object).isMasterEdge()
+                && Validators.isOfType(object, HighwayTag.class, HighwayTag.values())
+                && !this.isFlagged(object.getOsmIdentifier());
+    }
+```
+The valid objects are then checked for car accessibility. If the object meets any of the two conditions mentioned above for a conflict to  occur, it will be flagged.
+```java
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Optional<Boolean> carAccessible = checkIfCarAccessible((Edge) object);
+        if (!carAccessible.isPresent())
+        {
+            return Optional.empty();
+        }
+        if (carAccessible.get() && HighwayTag.isMetricHighway(object)
+                && !HighwayTag.isCarNavigableHighway(object))
+        {
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(1, object.getOsmIdentifier())));
+        }
+        else if (!carAccessible.get() && HighwayTag.isCarNavigableHighway(object))
+        {
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+```
+The following method validates if an `AtlasObject` is car accessible or not. Car accessibility is determined by the three transportation tags -
+`MotorcarTag`,`MotorVehicleTag` and `VehicleTag`. If any one of the above is present, the tag's value will determine the car accessibility. The check for
+the tag is based on the hierarchy - `MotorcarTag` -> `MotorVehicleTag` -> `VehicleTag`.
+```java
+    private Optional<Boolean> checkIfCarAccessible(final Edge object)
+    {
+        String tagValue = null;
+        if (object.getTag(MotorcarTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(MotorcarTag.KEY).get();
+        }
+        else if (object.getTag(MotorVehicleTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(MotorVehicleTag.KEY).get();
+        }
+        else if (object.getTag(VehicleTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(VehicleTag.KEY).get();
+        }
+        if (NO.equalsIgnoreCase(tagValue))
+        {
+            return Optional.of(false);
+        }
+        if (YES.equalsIgnoreCase(tagValue))
+        {
+            return Optional.of(true);
+        }
+        return Optional.empty();
+    }
+```
+To learn more about the code, please look at the comments in the source code for the check.  
+[ConflictingCarAccessibilityCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java)

--- a/docs/checks/conflictingCarAccessibilityCheck.md
+++ b/docs/checks/conflictingCarAccessibilityCheck.md
@@ -20,97 +20,10 @@ Our first goal is to validate the incoming Atlas object. Valid features for this
 * Does not contain any conditional tags such as `motor_vehicle:conditional`, `vehicle:conditional` or `motorcar:conditional` tags
 * Is a master edge
 * Is not an OSM way that has already been flagged
-```java
-    @Override
-  @Override
-    public boolean validCheckForObject(final AtlasObject object)
-    {
-        return object instanceof Edge
-                && !AccessTag.isNo(object)
-                && ((object.getTag(MotorVehicleTag.KEY).isPresent()
-                        && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(MotorcarTag.KEY).isPresent()
-                                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(VehicleTag.KEY).isPresent())
-                                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
-                && ((Edge) object).isMasterEdge()
-                && Validators.isOfType(object, HighwayTag.class, HighwayTag.values())
-                && !this.isFlagged(object.getOsmIdentifier());
-    }
-```
-The valid objects are then checked for car accessibility and designated vehicle use only tags. If the object meets any of the two conditions mentioned above for a conflict to  occur and does not have a designed use tag, it will be flagged. This
-method also flags objects with specific vehicle use only tag (such tags can be given in the config file; if not specified, default set of tags in the source code would be considered) but have car navigable highway tag.
-```java
-    @Override
-    protected Optional<CheckFlag> flag(final AtlasObject object)
-    {
-        boolean isOverridingTag = false;
-        final Optional<Boolean> carAccessible = checkIfCarAccessible((Edge) object);
-        if (!carAccessible.isPresent())
-        {
-            return Optional.empty();
-        }
-        for (final String tagKey : object.getOsmTags().keySet())
-        {
-            if (tagsFilter.contains(tagKey) && object.getTag(tagKey).get().equalsIgnoreCase(YES))
-            {
-                isOverridingTag = true;
-                break;
-            }
-        }
-        if (isOverridingTag && !carAccessible.get() && HighwayTag.isCarNavigableHighway(object))
-        {
-            this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(this.createFlag(object,
-                    this.getLocalizedInstruction(2, object.getOsmIdentifier())));
-        }
-        else if (!isOverridingTag && carAccessible.get() && HighwayTag.isMetricHighway(object)
-                && !HighwayTag.isCarNavigableHighway(object))
-        {
-            this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(this.createFlag(object,
-                    this.getLocalizedInstruction(1, object.getOsmIdentifier())));
-        }
-        else if (!isOverridingTag && !carAccessible.get()
-                && HighwayTag.isCarNavigableHighway(object))
-        {
-            this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(this.createFlag(object,
-                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
-        }
 
-        return Optional.empty();
-    }
-```
-The following method validates if an `AtlasObject` is car accessible or not. Car accessibility is determined by the three transportation tags -
-`MotorcarTag`,`MotorVehicleTag` and `VehicleTag`. If any one of the above is present, the tag's value will determine the car accessibility. The check for
-the tag is based on the hierarchy - `MotorcarTag` -> `MotorVehicleTag` -> `VehicleTag`.
-```java
-   private Optional<Boolean> checkIfCarAccessible(final Edge object)
-    {
-        String tagValue = null;
-        if (object.getTag(MotorcarTag.KEY).isPresent())
-        {
-            tagValue = object.getTag(MotorcarTag.KEY).get();
-        }
-        else if (object.getTag(MotorVehicleTag.KEY).isPresent())
-        {
-            tagValue = object.getTag(MotorVehicleTag.KEY).get();
-        }
-        else if (object.getTag(VehicleTag.KEY).isPresent())
-        {
-            tagValue = object.getTag(VehicleTag.KEY).get();
-        }
-        if (NO.equalsIgnoreCase(tagValue))
-        {
-            return Optional.of(false);
-        }
-        if (YES.equalsIgnoreCase(tagValue))
-        {
-            return Optional.of(true);
-        }
-        return Optional.empty();
-    }
-```
+The valid objects are then checked for car accessibility and designated vehicle tags. A helper method validates if an `AtlasObject` is car accessible or not. Car accessibility is determined by the three transportation tags - `MotorcarTag`,`MotorVehicleTag` and `VehicleTag`. If any one of the above is present, the tag's value will determine the car accessibility. The check for 
+the tag is based on the hierarchy - `MotorcarTag` -> `MotorVehicleTag` -> `VehicleTag`. If the object 
+meets any of the three conditions mentioned above for a conflict to  occur, it will be flagged. Designated vehicle tags can be given in the config file; if not specified, default set of tags in the source code will be considered for the check.
+
 To learn more about the code, please look at the comments in the source code for the check.  
 [ConflictingCarAccessibilityCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java)

--- a/docs/checks/conflictingCarAccessibilityCheck.md
+++ b/docs/checks/conflictingCarAccessibilityCheck.md
@@ -5,7 +5,7 @@ This check flags roads that have conflicting highway and transportation tags. A 
 access tag value with no specific vehicle use only tag 
  * A non-car navigable highway tag value combined with an open car access tag value
  
-Roads that are car navigable with specific vehicle use only tags such as `Motorcycle`=`YES` but have `Access`=`YES` would also be tagged in this check to prevent general use.
+Roads that are car navigable with designated vehicle tags such as `Motorcycle`=`YES` but have `Access`=`YES` would also be tagged in this check to prevent general use.
 #### Live Examples
 1. The way [id:369590090](https://www.openstreetmap.org/way/369590090) has conflicting values between `HighwayTag` (`highway`=`RESIDENTIAL`) and `VehicleTag`(`vehicle`=`NO`). This has `bicyle`=`DESIGNATED` and so the `Highway` tag should have been `highway=CYCLEWAY`.
 #### Code Review

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -38,12 +38,11 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
             CAR_NAVIGABLE_RESTRICTED_ACCESS_HIGHWAY_INSTRUCTION,
             CAR_ACCESSIBLE_NON_CAR_NAVIGABLE_INSTRUCTION,
             CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION);
-    private static final List<String> MODES_OF_TRANSPORTATION = Arrays
-            .asList(MotorVehicleTag.KEY, VehicleTag.KEY, MotorcarTag.KEY);
+    private static final List<String> MODES_OF_TRANSPORTATION = Arrays.asList(MotorVehicleTag.KEY,
+            VehicleTag.KEY, MotorcarTag.KEY);
     private static final String NO = "no";
-    private static final String TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT =
-            "bus->yes|minibus->yes|motorcycle->yes|taxi->yes|tourist_bus->yes|share_taxi->yes|psv->yes|good->yes|hsv->yes|"
-                    + "agricultural->yes|snowmobile->yes|hov->yes|public_transportation->yes|emergency->yes|disabled->yes|hazmat->yes";
+    private static final String TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = "bus->yes|minibus->yes|motorcycle->yes|taxi->yes|tourist_bus->yes|share_taxi->yes|psv->yes|good->yes|hsv->yes|"
+            + "agricultural->yes|snowmobile->yes|hov->yes|public_transportation->yes|emergency->yes|disabled->yes|hazmat->yes";
     private static final String YES = "yes";
     private static final long serialVersionUID = 8896036998080132728L;
     private final TaggableFilter designatedVehicleTagFilter;
@@ -53,7 +52,8 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * checks with this constructor, supplying a configuration that can be used to adjust any
      * parameters that the check uses during operation.
      *
-     * @param configuration the JSON configuration for this check
+     * @param configuration
+     *            the JSON configuration for this check
      */
     public ConflictingCarAccessibilityCheck(final Configuration configuration)
     {
@@ -70,7 +70,8 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * `MotorcarTag` or `VehicleTag` and none of these are conditional tags 5) Is a master edge 6)
      * An edge with the same OSM id has not already been flagged.
      *
-     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object
+     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return {@code true} if this object should be checked
      */
     @Override
@@ -80,7 +81,8 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
         return object instanceof Edge
                 // Make sure that AccessTag for the object is not "no"
                 && !AccessTag.isNo(object)
-                // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag tags
+                // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
+                // tags
                 // and does not contain any conditional restrictions on these tags
                 && isNotConditionalTag(object)
                 // Make sure that only master edges are considered
@@ -94,9 +96,10 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     /**
      * This is the actual function that will check to see whether the object needs to be flagged.
      *
-     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object
+     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return an optional {@link CheckFlag} object that contains the problem object and
-     * instructions on how to fix it, or the reason the object was flagged
+     *         instructions on how to fix it, or the reason the object was flagged
      */
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
@@ -149,10 +152,11 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * the three transporation tags : {@link MotorcarTag}, {@link MotorVehicleTag} and
      * {@link VehicleTag}.
      *
-     * @param object the {@link AtlasObject} that needs to be checked for car accessibility.
+     * @param object
+     *            the {@link AtlasObject} that needs to be checked for car accessibility.
      * @return an optional {@link Boolean} to indicate if the {@link AtlasObject} is car accessible
-     * or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
-     * check
+     *         or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
+     *         check
      */
     private Optional<Boolean> checkIfCarAccessible(final Edge object)
     {
@@ -192,18 +196,19 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
 
     /**
      * This is a helper function that evaluates if the given {@link AtlasObject} has any of
-     * MotorVehicleTag or MotorcarTag or VehicleTag tags
-     * and does not contain any conditional restrictions on these tags
+     * MotorVehicleTag or MotorcarTag or VehicleTag tags and does not contain any conditional
+     * restrictions on these tags
      *
-     * @param object the {@link AtlasObject} that needs to be checked for conditional tag on any of MotorVehicleTag or MotorcarTag or
-     *               VehicleTag tags.
-     * @return {@code true} if any of the transportation tags is present and does not have conditional tag associated with it
+     * @param object
+     *            the {@link AtlasObject} that needs to be checked for conditional tag on any of
+     *            MotorVehicleTag or MotorcarTag or VehicleTag tags.
+     * @return {@code true} if any of the transportation tags is present and does not have
+     *         conditional tag associated with it
      */
     private boolean isNotConditionalTag(final AtlasObject object)
     {
-        return MODES_OF_TRANSPORTATION
-                .stream().anyMatch(tagKey -> object.getTag(tagKey).isPresent()
-                        && !object.getTag(tagKey + CONDITIONAL).isPresent());
+        return MODES_OF_TRANSPORTATION.stream().anyMatch(tagKey -> object.getTag(tagKey).isPresent()
+                && !object.getTag(tagKey + CONDITIONAL).isPresent());
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -1,0 +1,147 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.AccessTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.MotorVehicleTag;
+import org.openstreetmap.atlas.tags.MotorcarTag;
+import org.openstreetmap.atlas.tags.VehicleTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * This check flags {@link Edge} that have
+ *
+ * @author sayana
+ */
+public class ConflictingCarAccessibilityCheck extends BaseCheck
+{
+    private static final String CAR_NAVIGABLE_HIGHWAY_INSTRUCTION = "This OSM way {0,number,#} has a car navigable highway tag value combined with a restrictive car access tag value. Please verify and make proper corrections if needed.";
+    private static final String METRIC_HIGHWAY_INSTRUCTION = "This OSM way  {0,number,#} has a non-car navigable highway tag value combined with an open car access tag value. Please verify and make proper corrections if needed.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(CAR_NAVIGABLE_HIGHWAY_INSTRUCTION, METRIC_HIGHWAY_INSTRUCTION);
+    private static final String NO = "no";
+    private static final String YES = "yes";
+    private static final long serialVersionUID = 8896036998080132728L;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration the JSON configuration for this check
+     */
+    public ConflictingCarAccessibilityCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * This function validates if given {@link AtlasObject} is valid for the check.
+     *
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        //Checks if the object is an instance of Edge
+        return object instanceof Edge
+                //Make sure that AccessTag for the object is not "no"
+                && !AccessTag.isNo(object)
+                //Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
+                && (object.getTag(MotorVehicleTag.KEY).isPresent()
+                || object.getTag(MotorcarTag.KEY).isPresent()
+                || object.getTag(VehicleTag.KEY).isPresent())
+                //Make sure that only master edges are considered
+                && ((Edge) object).isMasterEdge()
+                // Make sure that the object has a Highway tag
+                && Validators.isOfType(object, HighwayTag.class, HighwayTag.values())
+                //Make sure  that way sectioned duplicates are not considered
+                && !this.isFlagged(object.getOsmIdentifier());
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that contains the problem object and instructions on
+     * how to fix it, or the reason the object was flagged
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Optional<Boolean> carAccessible = checkIfCarAccessible((Edge) object);
+        //If carAccessible is empty, do not consider the object for the Check
+        if (!carAccessible.isPresent())
+        {
+            return Optional.empty();
+        }
+        // Checks if navigable highway with non-car access
+        if (carAccessible.get() && HighwayTag.isMetricHighway(object)
+                && !HighwayTag.isCarNavigableHighway(object))
+        {
+            ((Edge) object).highwayTag().getTagValue();
+
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(1, object.getOsmIdentifier())));
+        }
+        // Checks if metric highway with car-access
+        else if (!carAccessible.get()
+                && HighwayTag.isCarNavigableHighway(((Edge) object).highwayTag()))
+        {
+            this.markAsFlagged(object.getOsmIdentifier());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * This function evaluate if the given {@link AtlasObject} is car accessible or not.
+     *
+     * @param object the {@link AtlasObject} that needs to be checked for car accessibility.
+     * @return an optional {@link Boolean} to indicate if the {@link AtlasObject} is car accessible or not.
+     * If the Optional is empty, do not consider the {@link AtlasObject} for further check
+     */
+    private Optional<Boolean> checkIfCarAccessible(final Edge object)
+    {
+        String tagValue = null;
+        if (object.getTag(MotorcarTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(MotorcarTag.KEY).get();
+
+        }
+        else if (object.getTag(MotorVehicleTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(MotorVehicleTag.KEY).get();
+        }
+        else if (object.getTag(VehicleTag.KEY).isPresent())
+        {
+            tagValue = object.getTag(VehicleTag.KEY).get();
+        }
+        if (NO.equalsIgnoreCase(tagValue))
+        {
+            return Optional.of(false);
+        }
+        if (YES.equalsIgnoreCase(tagValue))
+        {
+            return Optional.of(true);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -82,7 +82,6 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
                 // Make sure that AccessTag for the object is not "no"
                 && !AccessTag.isNo(object)
                 // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
-                // tags
                 // and does not contain any conditional restrictions on these tags
                 && isNotConditionalTag(object)
                 // Make sure that only master edges are considered

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -17,18 +17,19 @@ import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * This check flags {@link Edge} with conflicting tag combinations resulting from combining
- * car-navigable/non-car-navigable highway with different modes of transportation tags. This check flags the following tag combinations:
- * 1) Car-navigable way with restricted car access and with no designated vehicle use tags like {@link org.openstreetmap.atlas.tags.MotorcycleTag}
- * 2) Car-navigable way with restricted car access and with designated vehicle use tags like {@link org.openstreetmap.atlas.tags.MotorcycleTag}
- * 3) Non-car-navigable way with open car access
+ * This check flags {@link Edge}s with conflicting tag combinations resulting from combining
+ * car-navigable/non-car-navigable highways with different modes of transportation tags. This check
+ * flags the following tag combinations: 1) Car-navigable way with restricted car access and with no
+ * designated vehicle use tags like {@link org.openstreetmap.atlas.tags.MotorcycleTag} 2)
+ * Car-navigable way with restricted car access and with designated vehicle use tags like
+ * {@link org.openstreetmap.atlas.tags.MotorcycleTag} 3) Non-car-navigable way with open car access
  * Car accessibility is determined by {@link #checkIfCarAccessible(Edge)}
  *
  * @author sayas01
  */
 public class ConflictingCarAccessibilityCheck extends BaseCheck
 {
-    private static final String CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION = "This OSM way  {0,number,#} is designated for specific vehicle uses, consider to add access=NO to prevent general uses.";
+    private static final String CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION = "This OSM way {0,number,#} is designated for specific vehicles only, consider adding access=NO to prevent general use.";
     private static final String CAR_ACCESSIBLE_NON_CAR_NAVIGABLE_INSTRUCTION = "This OSM way  {0,number,#} has a non-car navigable highway tag value combined with an open car access tag value, please verify and make proper corrections if needed.";
     private static final String CAR_NAVIGABLE_RESTRICTED_ACCESS_HIGHWAY_INSTRUCTION = "This OSM way {0,number,#} has a car navigable highway tag value combined with a restrictive car access tag value, please verify and make proper corrections if needed.";
     private static final String CONDITIONAL = ":conditional";
@@ -37,10 +38,10 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
             CAR_ACCESSIBLE_NON_CAR_NAVIGABLE_INSTRUCTION,
             CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION);
     private static final String NO = "no";
-    private static final List<String> TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = Arrays
-            .asList("bus", "minibus", "motorcycle", "taxi", "tourist_bus", "share_taxi", "psv",
-                    "goods", "hsv", "agricultural", "snowmobile", "hov", "public_transportation",
-                    "emergency", "disabled", "hazmat");
+    private static final List<String> TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = Arrays.asList("bus",
+            "minibus", "motorcycle", "taxi", "tourist_bus", "share_taxi", "psv", "goods", "hsv",
+            "agricultural", "snowmobile", "hov", "public_transportation", "emergency", "disabled",
+            "hazmat");
     private static final String YES = "yes";
     private static final long serialVersionUID = 8896036998080132728L;
     private final List<String> tagsFilter;
@@ -50,7 +51,8 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * checks with this constructor, supplying a configuration that can be used to adjust any
      * parameters that the check uses during operation.
      *
-     * @param configuration the JSON configuration for this check
+     * @param configuration
+     *            the JSON configuration for this check
      */
     public ConflictingCarAccessibilityCheck(final Configuration configuration)
     {
@@ -60,15 +62,14 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     }
 
     /**
-     * This function validates if given {@link AtlasObject} is valid for the check. A valid {@link AtlasObject} for this check must have the below properties:
-     * 1) Is an Edge
-     * 2) Has a highway tag
-     * 3) AccessTag for the object is not "no"
-     * 4) Has either `MotorVehicleTag` or `MotorcarTag` or `VehicleTag` and none of these are conditional tags
-     * 5) Is a master edge
-     * 6) Is not a way sectioned duplicate
+     * This function validates if given {@link AtlasObject} is valid for the check. A valid
+     * {@link AtlasObject} for this check must have the below properties: 1) Is an Edge 2) Has a
+     * highway tag 3) AccessTag for the object is not "no" 4) Has either `MotorVehicleTag` or
+     * `MotorcarTag` or `VehicleTag` and none of these are conditional tags 5) Is a master edge 6)
+     * An edge with the same OSM id has not already been flagged.
      *
-     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object
+     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return {@code true} if this object should be checked
      */
     @Override
@@ -81,25 +82,26 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
                 // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
                 // and does not contain any conditional restrictions on these tags
                 && ((object.getTag(MotorVehicleTag.KEY).isPresent()
-                && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
-                || (object.getTag(MotorcarTag.KEY).isPresent()
-                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
-                || (object.getTag(VehicleTag.KEY).isPresent())
-                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
+                        && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
+                        || (object.getTag(MotorcarTag.KEY).isPresent()
+                                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
+                        || (object.getTag(VehicleTag.KEY).isPresent())
+                                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
                 // Make sure that only master edges are considered
                 && ((Edge) object).isMasterEdge()
                 // Make sure that the object has a Highway tag
                 && Validators.isOfType(object, HighwayTag.class, HighwayTag.values())
-                // Make sure that way sectioned duplicates are not considered
+                // Make sure that the object has not been previously flagged
                 && !this.isFlagged(object.getOsmIdentifier());
     }
 
     /**
      * This is the actual function that will check to see whether the object needs to be flagged.
      *
-     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object
+     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return an optional {@link CheckFlag} object that contains the problem object and
-     * instructions on how to fix it, or the reason the object was flagged
+     *         instructions on how to fix it, or the reason the object was flagged
      */
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
@@ -156,13 +158,15 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     }
 
     /**
-     * This function evaluates if the given {@link AtlasObject} is car accessible or not based on the three transporation tags : {@link MotorcarTag},
-     * {@link MotorVehicleTag} and {@link VehicleTag}.
+     * This function evaluates if the given {@link AtlasObject} is car accessible or not based on
+     * the three transporation tags : {@link MotorcarTag}, {@link MotorVehicleTag} and
+     * {@link VehicleTag}.
      *
-     * @param object the {@link AtlasObject} that needs to be checked for car accessibility.
+     * @param object
+     *            the {@link AtlasObject} that needs to be checked for car accessibility.
      * @return an optional {@link Boolean} to indicate if the {@link AtlasObject} is car accessible
-     * or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
-     * check
+     *         or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
+     *         check
      */
     private Optional<Boolean> checkIfCarAccessible(final Edge object)
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -38,9 +38,12 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
             CAR_NAVIGABLE_RESTRICTED_ACCESS_HIGHWAY_INSTRUCTION,
             CAR_ACCESSIBLE_NON_CAR_NAVIGABLE_INSTRUCTION,
             CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION);
+    private static final List<String> MODES_OF_TRANSPORTATION = Arrays
+            .asList(MotorVehicleTag.KEY, VehicleTag.KEY, MotorcarTag.KEY);
     private static final String NO = "no";
-    private static final String TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = "bus->yes|minibus->yes|motorcycle->yes|taxi->yes|tourist_bus->yes|share_taxi->yes|psv->yes|good->yes|hsv->yes|"
-            + "agricultural->yes|snowmobile->yes|hov->yes|public_transportation->yes|emergency->yes|disabled->yes|hazmat->yes";
+    private static final String TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT =
+            "bus->yes|minibus->yes|motorcycle->yes|taxi->yes|tourist_bus->yes|share_taxi->yes|psv->yes|good->yes|hsv->yes|"
+                    + "agricultural->yes|snowmobile->yes|hov->yes|public_transportation->yes|emergency->yes|disabled->yes|hazmat->yes";
     private static final String YES = "yes";
     private static final long serialVersionUID = 8896036998080132728L;
     private final TaggableFilter designatedVehicleTagFilter;
@@ -50,8 +53,7 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * checks with this constructor, supplying a configuration that can be used to adjust any
      * parameters that the check uses during operation.
      *
-     * @param configuration
-     *            the JSON configuration for this check
+     * @param configuration the JSON configuration for this check
      */
     public ConflictingCarAccessibilityCheck(final Configuration configuration)
     {
@@ -68,8 +70,7 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * `MotorcarTag` or `VehicleTag` and none of these are conditional tags 5) Is a master edge 6)
      * An edge with the same OSM id has not already been flagged.
      *
-     * @param object
-     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return {@code true} if this object should be checked
      */
     @Override
@@ -79,14 +80,9 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
         return object instanceof Edge
                 // Make sure that AccessTag for the object is not "no"
                 && !AccessTag.isNo(object)
-                // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
+                // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag tags
                 // and does not contain any conditional restrictions on these tags
-                && ((object.getTag(MotorVehicleTag.KEY).isPresent()
-                        && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(MotorcarTag.KEY).isPresent()
-                                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(VehicleTag.KEY).isPresent())
-                                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
+                && isNotConditionalTag(object)
                 // Make sure that only master edges are considered
                 && ((Edge) object).isMasterEdge()
                 // Make sure that the object has a Highway tag
@@ -98,10 +94,9 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     /**
      * This is the actual function that will check to see whether the object needs to be flagged.
      *
-     * @param object
-     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return an optional {@link CheckFlag} object that contains the problem object and
-     *         instructions on how to fix it, or the reason the object was flagged
+     * instructions on how to fix it, or the reason the object was flagged
      */
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
@@ -154,11 +149,10 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * the three transporation tags : {@link MotorcarTag}, {@link MotorVehicleTag} and
      * {@link VehicleTag}.
      *
-     * @param object
-     *            the {@link AtlasObject} that needs to be checked for car accessibility.
+     * @param object the {@link AtlasObject} that needs to be checked for car accessibility.
      * @return an optional {@link Boolean} to indicate if the {@link AtlasObject} is car accessible
-     *         or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
-     *         check
+     * or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
+     * check
      */
     private Optional<Boolean> checkIfCarAccessible(final Edge object)
     {
@@ -195,4 +189,21 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
         }
         return Optional.empty();
     }
+
+    /**
+     * This is a helper function that evaluates if the given {@link AtlasObject} has any of
+     * MotorVehicleTag or MotorcarTag or VehicleTag tags
+     * and does not contain any conditional restrictions on these tags
+     *
+     * @param object the {@link AtlasObject} that needs to be checked for conditional tag on any of MotorVehicleTag or MotorcarTag or
+     *               VehicleTag tags.
+     * @return {@code true} if any of the transportation tags is present and does not have conditional tag associated with it
+     */
+    private boolean isNotConditionalTag(final AtlasObject object)
+    {
+        return MODES_OF_TRANSPORTATION
+                .stream().anyMatch(tagKey -> object.getTag(tagKey).isPresent()
+                        && !object.getTag(tagKey + CONDITIONAL).isPresent());
+    }
+
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -20,7 +20,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * This check flags {@link Edge} with conflicting tag combination resulting from combining
  * car-navigable/non-car-navigable highway with different modes of transportation tags.
  *
- * @author sayana
+ * @author sayas01
  */
 public class ConflictingCarAccessibilityCheck extends BaseCheck
 {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -106,17 +106,13 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        boolean isOverridingTag = false;
+        // Check if any one of the designated vehicle tag is present
+        final boolean isOverridingTag = this.designatedVehicleTagFilter.test(object);
         final Optional<Boolean> carAccessible = checkIfCarAccessible((Edge) object);
         // If carAccessible is empty, do not consider the object for flagging
         if (!carAccessible.isPresent())
         {
             return Optional.empty();
-        }
-        // Check if any one of the designated vehicle tag is present
-        if (this.designatedVehicleTagFilter.test(object))
-        {
-            isOverridingTag = true;
         }
         // Checks if the object has designated highway tag combined with non car access and car
         // navigable highway

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -38,8 +38,7 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
      * checks with this constructor, supplying a configuration that can be used to adjust any
      * parameters that the check uses during operation.
      *
-     * @param configuration
-     *            the JSON configuration for this check
+     * @param configuration the JSON configuration for this check
      */
     public ConflictingCarAccessibilityCheck(final Configuration configuration)
     {
@@ -49,8 +48,7 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     /**
      * This function validates if given {@link AtlasObject} is valid for the check.
      *
-     * @param object
-     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return {@code true} if this object should be checked
      */
     @Override
@@ -63,11 +61,11 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
                 // Make sure that the object has either MotorVehicleTag or MotorcarTag or VehicleTag
                 // and does not contain any conditional restrictions on these tags
                 && ((object.getTag(MotorVehicleTag.KEY).isPresent()
-                        && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(MotorcarTag.KEY).isPresent()
-                                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
-                        || (object.getTag(VehicleTag.KEY).isPresent())
-                                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
+                && !object.getTag(MotorVehicleTag.KEY + CONDITIONAL).isPresent())
+                || (object.getTag(MotorcarTag.KEY).isPresent()
+                && !object.getTag(MotorcarTag.KEY + CONDITIONAL).isPresent())
+                || (object.getTag(VehicleTag.KEY).isPresent())
+                && !object.getTag(VehicleTag.KEY + CONDITIONAL).isPresent())
                 // Make sure that only master edges are considered
                 && ((Edge) object).isMasterEdge()
                 // Make sure that the object has a Highway tag
@@ -79,10 +77,9 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     /**
      * This is the actual function that will check to see whether the object needs to be flagged.
      *
-     * @param object
-     *            the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
+     * @param object the {@link AtlasObject} supplied by the Atlas-Checks framework for evaluation
      * @return an optional {@link CheckFlag} object that contains the problem object and
-     *         instructions on how to fix it, or the reason the object was flagged
+     * instructions on how to fix it, or the reason the object was flagged
      */
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
@@ -121,11 +118,10 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
     /**
      * This function evaluates if the given {@link AtlasObject} is car accessible or not.
      *
-     * @param object
-     *            the {@link AtlasObject} that needs to be checked for car accessibility.
+     * @param object the {@link AtlasObject} that needs to be checked for car accessibility.
      * @return an optional {@link Boolean} to indicate if the {@link AtlasObject} is car accessible
-     *         or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
-     *         check
+     * or not. If the Optional is empty, do not consider the {@link AtlasObject} for further
+     * check
      */
     private Optional<Boolean> checkIfCarAccessible(final Edge object)
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -37,9 +37,10 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
             CAR_ACCESSIBLE_NON_CAR_NAVIGABLE_INSTRUCTION,
             CAR_ACCESSIBLE_DESIGNATED_HIGHWAY_INSTRUCTION);
     private static final String NO = "no";
-    private static final List<String> TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = Arrays.asList("bus",
-            "minibus", "motorcycle", "psv", "public_transportation", "good", "hsv", "agricultural",
-            "snowmobile", "hov", "emergency", "disabled", "hazmat");
+    private static final List<String> TAGS_OVERRIDING_ACCESSIBILITY_DEFAULT = Arrays
+            .asList("bus", "minibus", "motorcycle", "taxi", "tourist_bus", "share_taxi", "psv",
+                    "goods", "hsv", "agricultural", "snowmobile", "hov", "public_transportation",
+                    "emergency", "disabled", "hazmat");
     private static final String YES = "yes";
     private static final long serialVersionUID = 8896036998080132728L;
     private final List<String> tagsFilter;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheck.java
@@ -210,5 +210,4 @@ public class ConflictingCarAccessibilityCheck extends BaseCheck
         return MODES_OF_TRANSPORTATION.stream().anyMatch(tagKey -> object.getTag(tagKey).isPresent()
                 && !object.getTag(tagKey + CONDITIONAL).isPresent());
     }
-
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -45,6 +45,23 @@ public class ConflictingCarAccessibilityCheckTest
     }
 
     @Test
+    public void testDesignatedUseCarNavigable()
+    {
+        this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(3, flags.size()));
+    }
+
+    @Test
+    public void testDesignatedUseCarNavigableInstruction()
+    {
+        this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verify(flag -> Assert
+                .assertTrue(flag.getInstructions().contains("designated for specific vehicle")));
+    }
+
+    @Test
     public void testMetricHighwayInstruction()
     {
         this.verifier.actual(this.setup.carAccessMetricHighwayAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -1,0 +1,72 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link ConflictingCarAccessibilityCheck}.
+ *
+ * @author sayana
+ */
+public class ConflictingCarAccessibilityCheckTest
+{
+    @Rule
+    public ConflictingCarAccessibilityCheckTestRule setup = new ConflictingCarAccessibilityCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testCarAccessCarNavigable()
+    {
+        this.verifier.actual(this.setup.carAccessCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void testCarAccessMetricHighway()
+    {
+        this.verifier.actual(this.setup.carAccessMetricHighwayAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
+    }
+
+    @Test
+    public void testCarNavigableHighwayInstruction()
+    {
+        this.verifier.actual(this.setup.nonCarAccessCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verify(
+                flag -> Assert
+                        .assertTrue(flag.getInstructions().contains("restrictive car access")));
+    }
+
+    @Test
+    public void testMetricHighwayInstruction()
+    {
+        this.verifier.actual(this.setup.carAccessMetricHighwayAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verify(
+                flag -> Assert.assertTrue(flag.getInstructions().contains("open car access")));
+    }
+
+    @Test
+    public void testNonCarAccessCarNavigable()
+    {
+        this.verifier.actual(this.setup.nonCarAccessCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(6, flags.size()));
+    }
+
+    @Test
+    public void testNonCarAccessMetricHighway()
+    {
+        this.verifier.actual(this.setup.nonCarAccessMetricHighwayAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -40,9 +40,8 @@ public class ConflictingCarAccessibilityCheckTest
     {
         this.verifier.actual(this.setup.nonCarAccessCarNavigableAtlas(),
                 new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.verify(
-                flag -> Assert
-                        .assertTrue(flag.getInstructions().contains("restrictive car access")));
+        this.verifier.verify(flag -> Assert
+                .assertTrue(flag.getInstructions().contains("restrictive car access")));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -57,9 +57,9 @@ public class ConflictingCarAccessibilityCheckTest
     {
         this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),
                 new ConflictingCarAccessibilityCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"ConflictingCarAccessibilityCheck\":{\"accessibility.overriding.tags\":[\"bus\",\"taxi\"]}}")));
+                        "{\"ConflictingCarAccessibilityCheck\":{\"accessibility.overriding.tags\":\"minibus->yes|taxi->yes\"}}")));
         this.verifier.verify(flag -> Assert
-                .assertTrue(flag.getInstructions().contains("restrictive car access")));
+                .assertTrue(flag.getInstructions().contains("designated for specific vehicles")));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class ConflictingCarAccessibilityCheckTest
     {
         this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),
                 new ConflictingCarAccessibilityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.verify(flag -> Assert
-                .assertTrue(flag.getInstructions().contains("designated for specific vehicle")));
+        this.verifier.verify(flag -> Assert.assertTrue(
+                flag.getInstructions().contains("designated for specific vehicles only")));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -9,7 +9,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 /**
  * Tests for {@link ConflictingCarAccessibilityCheck}.
  *
- * @author sayana
+ * @author sayas01
  */
 public class ConflictingCarAccessibilityCheckTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTest.java
@@ -53,6 +53,16 @@ public class ConflictingCarAccessibilityCheckTest
     }
 
     @Test
+    public void testDesignatedUseCarNavigableInlineConfigInstruction()
+    {
+        this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),
+                new ConflictingCarAccessibilityCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"ConflictingCarAccessibilityCheck\":{\"accessibility.overriding.tags\":[\"bus\",\"taxi\"]}}")));
+        this.verifier.verify(flag -> Assert
+                .assertTrue(flag.getInstructions().contains("restrictive car access")));
+    }
+
+    @Test
     public void testDesignatedUseCarNavigableInstruction()
     {
         this.verifier.actual(this.setup.designatedUseCarNavigableAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -91,13 +91,9 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                                     "access=yes", "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=MOTORWAY",
-                                    "access=yes", "vehicle=yes", "motorcar=yes",
-                                    "motor_vehicle=no" }),
-                    @TestAtlas.Edge(id = "1007000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_13),
-                            @TestAtlas.Loc(value = TEST_1) }, tags = { "highway=PRIMARY",
-                                    "access=yes", "motorcar=BUS", "motor_vehicle=yes" }), })
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=SERVICE",
+                                    "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
+                                    "motor_vehicle=no" }), })
     private Atlas carAccessMetricHighwayAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -7,7 +7,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 /**
  * {@link ConflictingCarAccessibilityCheck} test data.
  *
- * @author sayana
+ * @author sayas01
  */
 public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -38,27 +38,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=yes" }),
+                                    "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=ROAD", "access=yes",
-                            "motorcar=yes" }),
+                                    "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes" }),
+                                    "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes", "vehicle=no" }),
+                                    "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
+                                    "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1001100001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
+                                    "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
     private Atlas carAccessCarNavigableAtlas;
     @TestAtlas(
             // nodes
@@ -74,28 +74,28 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=STEPS",
-                            "access=yes", "vehicle=yes" }),
+                                    "access=yes", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=STEPS",
-                            "access=yes", "motorcar=yes" }),
+                                    "access=yes", "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=STEPS",
-                            "access=yes", "motor_vehicle=yes" }),
+                                    "access=yes", "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motor_vehicle=yes", "vehicle=no" }),
+                                    "access=yes", "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=MOTORWAY",
-                            "access=yes", "vehicle=yes", "motorcar=yes",
-                            "motor_vehicle=no" }),
+                                    "access=yes", "vehicle=yes", "motorcar=yes",
+                                    "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_13),
                             @TestAtlas.Loc(value = TEST_1) }, tags = { "highway=PRIMARY",
-                            "access=yes", "motorcar=BUS", "motor_vehicle=yes" }), })
+                                    "access=yes", "motorcar=BUS", "motor_vehicle=yes" }), })
     private Atlas carAccessMetricHighwayAtlas;
     @TestAtlas(
             // nodes
@@ -114,27 +114,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                    "highway=MOTORWAY", "access=yes", "vehicle=no" }),
+                            "highway=MOTORWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                            "motorcar=no" }),
+                                    "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=no" }),
+                                    "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=ROAD",
-                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                                    "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=no", "vehicle=yes" }),
+                                    "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes", "motorcar=no" }), })
+                                    "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessCarNavigableAtlas;
     @TestAtlas(
             // nodes
@@ -153,27 +153,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                    "highway=FOOTWAY", "access=yes", "vehicle=no" }),
+                            "highway=FOOTWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motorcar=no" }),
+                                    "access=yes", "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motor_vehicle=no" }),
+                                    "access=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY",
-                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                                    "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
-                            "motor_vehicle=no", "vehicle=yes" }),
+                                    "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN",
-                            "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
+                                    "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessMetricHighwayAtlas;
 
     public Atlas carAccessCarNavigableAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -13,9 +13,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
 {
     private static final String TEST_1 = "47.2136626201459,-122.443275382856";
     private static final String TEST_10 = "47.2136413561665,-122.436028431137";
-    private static final String TEST_11 = "47.2141623212065,-122.443729295599";
     private static final String TEST_12 = "47.2132054427106,-122.44382320858";
-    private static final String TEST_13 = "47.2132267068647,-122.435339735941";
     private static final String TEST_2 = "47.2138327316739,-122.44258668766";
     private static final String TEST_3 = "47.2136626201459,-122.441897992465";
     private static final String TEST_4 = "47.2138114677627,-122.440990166979";
@@ -33,33 +31,32 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)) },
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)), },
             // edges
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=yes" }),
+                                    "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=ROAD", "access=yes",
-                            "motorcar=yes" }),
+                                    "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes" }),
+                                    "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes", "vehicle=no" }),
+                                    "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
+                                    "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1001100001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                            "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
+                                    "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
     private Atlas carAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with car access
     @TestAtlas(
@@ -70,30 +67,29 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)) },
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)), },
             // edges
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=STEPS",
-                            "access=yes", "vehicle=yes" }),
+                                    "access=yes", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=STEPS",
-                            "access=yes", "motorcar=yes" }),
+                                    "access=yes", "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=STEPS",
-                            "access=yes", "motor_vehicle=yes" }),
+                                    "access=yes", "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motor_vehicle=yes", "vehicle=no" }),
+                                    "access=yes", "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=SERVICE",
-                            "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
-                            "motor_vehicle=no" }), })
+                                    "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
+                                    "motor_vehicle=no" }), })
     private Atlas carAccessMetricHighwayAtlas;
     // Atlas to test designated use edges that are car navigable
     @TestAtlas(
@@ -103,25 +99,20 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)), },
 
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                    "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
+                            "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                            "motorcar=no", "bus=yes" }),
+                                    "motorcar=no", "bus=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=no", "motorcycle=yes" }), })
+                                    "motor_vehicle=no", "motorcycle=yes" }), })
     private Atlas designatedUseCarNavigableAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(
@@ -132,36 +123,34 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
 
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                    "highway=MOTORWAY", "access=yes", "vehicle=no" }),
+                            "highway=MOTORWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                            "motorcar=no" }),
+                                    "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=no" }),
+                                    "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=ROAD",
-                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                                    "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=no", "vehicle=yes" }),
+                                    "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
-                            "motor_vehicle=yes", "motorcar=no" }), })
+                                    "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with non-car access
     @TestAtlas(
@@ -172,36 +161,34 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
 
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                    "highway=FOOTWAY", "access=yes", "vehicle=no" }),
+                            "highway=FOOTWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motorcar=no" }),
+                                    "access=yes", "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=FOOTWAY",
-                            "access=yes", "motor_vehicle=no" }),
+                                    "access=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY",
-                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                                    "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
-                            "motor_vehicle=no", "vehicle=yes" }),
+                                    "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN",
-                            "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
+                                    "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessMetricHighwayAtlas;
 
     public Atlas carAccessCarNavigableAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -112,7 +112,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=no", "motorcycle=yes" }), })
+                                    "motor_vehicle=no", "minibus=yes" }), })
     private Atlas designatedUseCarNavigableAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -95,6 +95,34 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                                     "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
                                     "motor_vehicle=no" }), })
     private Atlas carAccessMetricHighwayAtlas;
+    // Atlas to test designated use edges that are car navigable
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
+                            "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
+                    @TestAtlas.Edge(id = "1001000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3),
+                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
+                                    "motorcar=no", "bus=yes" }),
+                    @TestAtlas.Edge(id = "1002000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                                    "motor_vehicle=no", "motorcycle=yes" }), })
+    private Atlas designatedUseCarNavigableAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(
             // nodes
@@ -184,6 +212,11 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
     public Atlas carAccessMetricHighwayAtlas()
     {
         return this.carAccessMetricHighwayAtlas;
+    }
+
+    public Atlas designatedUseCarNavigableAtlas()
+    {
+        return this.designatedUseCarNavigableAtlas;
     }
 
     public Atlas nonCarAccessCarNavigableAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -1,0 +1,198 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * {@link ConflictingCarAccessibilityCheck} test data.
+ *
+ * @author sayana
+ */
+public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_10 = "47.2136413561665,-122.436028431137";
+    private static final String TEST_11 = "47.2141623212065,-122.443729295599";
+    private static final String TEST_12 = "47.2132054427106,-122.44382320858";
+    private static final String TEST_13 = "47.2132267068647,-122.435339735941";
+    private static final String TEST_2 = "47.2138327316739,-122.44258668766";
+    private static final String TEST_3 = "47.2136626201459,-122.441897992465";
+    private static final String TEST_4 = "47.2138114677627,-122.440990166979";
+    private static final String TEST_5 = "47.2136200921786,-122.44001973284";
+    private static final String TEST_6 = "47.2135137721113,-122.439127559518";
+    private static final String TEST_7 = "47.2136200921786,-122.438157125378";
+    private static final String TEST_8 = "47.2136413561665,-122.437468430183";
+    private static final String TEST_9 = "47.2137689399148,-122.436717126333";
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
+                            @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes",
+                            "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1001000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
+                            @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=ROAD", "access=yes",
+                            "motorcar=yes" }),
+                    @TestAtlas.Edge(id = "1002000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
+                            @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=ROAD", "access=yes",
+                            "motor_vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1008000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3),
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+                            "motor_vehicle=yes", "vehicle=no" }),
+                    @TestAtlas.Edge(id = "1009000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+                            "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
+                    @TestAtlas.Edge(id = "1001100001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+                            "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
+    private Atlas carAccessCarNavigableAtlas;
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
+                            @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=STEPS",
+                            "access=yes", "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1001000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
+                            @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=STEPS",
+                            "access=yes", "motorcar=yes" }),
+                    @TestAtlas.Edge(id = "1002000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
+                            @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=STEPS",
+                            "access=yes", "motor_vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1008000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3),
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=FOOTWAY",
+                            "access=yes", "motor_vehicle=yes", "vehicle=no" }),
+                    @TestAtlas.Edge(id = "1009000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=MOTORWAY",
+                            "access=yes", "vehicle=yes", "motorcar=yes",
+                            "motor_vehicle=no" }),
+                    @TestAtlas.Edge(id = "1007000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_13),
+                            @TestAtlas.Loc(value = TEST_1) }, tags = { "highway=PRIMARY",
+                            "access=yes", "motorcar=BUS", "motor_vehicle=yes" }), })
+    private Atlas carAccessMetricHighwayAtlas;
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
+                    "highway=MOTORWAY", "access=yes", "vehicle=no" }),
+                    @TestAtlas.Edge(id = "1001000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3),
+                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
+                            "motorcar=no" }),
+                    @TestAtlas.Edge(id = "1002000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                            "motor_vehicle=no" }),
+                    @TestAtlas.Edge(id = "1004000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_9),
+                            @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=ROAD",
+                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1006000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_12),
+                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                            "motor_vehicle=no", "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1007000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_12),
+                            @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
+                            "motor_vehicle=yes", "motorcar=no" }), })
+    private Atlas nonCarAccessCarNavigableAtlas;
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_11)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_13)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
+                    "highway=FOOTWAY", "access=yes", "vehicle=no" }),
+                    @TestAtlas.Edge(id = "1001000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_3),
+                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=FOOTWAY",
+                            "access=yes", "motorcar=no" }),
+                    @TestAtlas.Edge(id = "1002000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_5),
+                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=FOOTWAY",
+                            "access=yes", "motor_vehicle=no" }),
+                    @TestAtlas.Edge(id = "1004000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_9),
+                            @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY",
+                            "access=yes", "motorcar=no", "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1006000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_12),
+                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
+                            "motor_vehicle=no", "vehicle=yes" }),
+                    @TestAtlas.Edge(id = "1007000001", coordinates = {
+                            @TestAtlas.Loc(value = TEST_12),
+                            @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN",
+                            "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
+    private Atlas nonCarAccessMetricHighwayAtlas;
+
+    public Atlas carAccessCarNavigableAtlas()
+    {
+        return this.carAccessCarNavigableAtlas;
+    }
+
+    public Atlas carAccessMetricHighwayAtlas()
+    {
+        return this.carAccessMetricHighwayAtlas;
+    }
+
+    public Atlas nonCarAccessCarNavigableAtlas()
+    {
+        return this.nonCarAccessCarNavigableAtlas;
+    }
+
+    public Atlas nonCarAccessMetricHighwayAtlas()
+    {
+        return this.nonCarAccessMetricHighwayAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -39,27 +39,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes",
-                                    "vehicle=yes" }),
+                            "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=ROAD", "access=yes",
-                                    "motorcar=yes" }),
+                            "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=yes" }),
+                            "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=yes", "vehicle=no" }),
+                            "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                                    "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
+                            "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1001100001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
-                                    "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
+                            "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
     private Atlas carAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with car access
     @TestAtlas(
@@ -76,24 +76,24 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             edges = {
                     @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
                             @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=STEPS",
-                                    "access=yes", "vehicle=yes" }),
+                            "access=yes", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
                             @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=STEPS",
-                                    "access=yes", "motorcar=yes" }),
+                            "access=yes", "motorcar=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
                             @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=STEPS",
-                                    "access=yes", "motor_vehicle=yes" }),
+                            "access=yes", "motor_vehicle=yes" }),
                     @TestAtlas.Edge(id = "1008000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motor_vehicle=yes", "vehicle=no" }),
+                            "access=yes", "motor_vehicle=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1009000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=SERVICE",
-                                    "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
-                                    "motor_vehicle=no" }), })
+                            "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
+                            "motor_vehicle=no" }), })
     private Atlas carAccessMetricHighwayAtlas;
     // Atlas to test designated use edges that are car navigable
     @TestAtlas(
@@ -113,15 +113,15 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
+                    "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                                    "motorcar=no", "bus=yes" }),
+                            "motorcar=no", "bus=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=no", "motorcycle=yes" }), })
+                            "motor_vehicle=no", "motorcycle=yes" }), })
     private Atlas designatedUseCarNavigableAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(
@@ -141,27 +141,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=MOTORWAY", "access=yes", "vehicle=no" }),
+                    "highway=MOTORWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                                    "motorcar=no" }),
+                            "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=no" }),
+                            "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=ROAD",
-                                    "access=yes", "motorcar=no", "vehicle=yes" }),
+                            "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=no", "vehicle=yes" }),
+                            "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=yes", "motorcar=no" }), })
+                            "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with non-car access
     @TestAtlas(
@@ -181,27 +181,27 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
             // edges
             edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
                     @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=FOOTWAY", "access=yes", "vehicle=no" }),
+                    "highway=FOOTWAY", "access=yes", "vehicle=no" }),
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motorcar=no" }),
+                            "access=yes", "motorcar=no" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motor_vehicle=no" }),
+                            "access=yes", "motor_vehicle=no" }),
                     @TestAtlas.Edge(id = "1004000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_9),
                             @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY",
-                                    "access=yes", "motorcar=no", "vehicle=yes" }),
+                            "access=yes", "motorcar=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1006000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
-                                    "motor_vehicle=no", "vehicle=yes" }),
+                            "motor_vehicle=no", "vehicle=yes" }),
                     @TestAtlas.Edge(id = "1007000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_12),
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN",
-                                    "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
+                            "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessMetricHighwayAtlas;
 
     public Atlas carAccessCarNavigableAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -24,6 +24,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
     private static final String TEST_7 = "47.2136200921786,-122.438157125378";
     private static final String TEST_8 = "47.2136413561665,-122.437468430183";
     private static final String TEST_9 = "47.2137689399148,-122.436717126333";
+    // Atlas to test car navigable edges with car access
     @TestAtlas(
             // nodes
             nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
@@ -60,6 +61,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                             @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
                                     "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
     private Atlas carAccessCarNavigableAtlas;
+    // Atlas to test non-car navigable edges with car access
     @TestAtlas(
             // nodes
             nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
@@ -97,6 +99,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                             @TestAtlas.Loc(value = TEST_1) }, tags = { "highway=PRIMARY",
                                     "access=yes", "motorcar=BUS", "motor_vehicle=yes" }), })
     private Atlas carAccessMetricHighwayAtlas;
+    // Atlas to test car navigable edges with non-car access
     @TestAtlas(
             // nodes
             nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
@@ -136,6 +139,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                             @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessCarNavigableAtlas;
+    // Atlas to test non-car navigable edges with non-car access
     @TestAtlas(
             // nodes
             nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -108,7 +108,7 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
                     @TestAtlas.Edge(id = "1001000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_3),
                             @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
-                                    "motorcar=no", "bus=yes" }),
+                                    "motorcar=no", "minibus=yes" }),
                     @TestAtlas.Edge(id = "1002000001", coordinates = {
                             @TestAtlas.Loc(value = TEST_5),
                             @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingCarAccessibilityCheckTestRule.java
@@ -3,6 +3,9 @@ package org.openstreetmap.atlas.checks.validation.tag;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 /**
  * {@link ConflictingCarAccessibilityCheck} test data.
@@ -25,170 +28,150 @@ public class ConflictingCarAccessibilityCheckTestRule extends CoreTestRule
     // Atlas to test car navigable edges with car access
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)), },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_7)),
+                    @Node(coordinates = @Loc(value = TEST_8)), },
             // edges
-            edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
-                            @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes",
-                                    "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1001000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
-                            @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=ROAD", "access=yes",
-                                    "motorcar=yes" }),
-                    @TestAtlas.Edge(id = "1002000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
-                            @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=ROAD", "access=yes",
-                                    "motor_vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1008000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+            edges = { @Edge(id = "1006000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_3) }, tags = { "highway=ROAD", "access=yes", "vehicle=yes" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = { "highway=ROAD",
+                                    "access=yes", "motorcar=yes" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6), @Loc(value = TEST_7) }, tags = { "highway=ROAD",
+                                    "access=yes", "motor_vehicle=yes" }),
+                    @Edge(id = "1008000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=yes", "vehicle=no" }),
-                    @TestAtlas.Edge(id = "1009000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1009000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
                                     "vehicle=yes", "motorcar=yes", "motor_vehicle=no" }),
-                    @TestAtlas.Edge(id = "1001100001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1001100001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_8) }, tags = { "highway=ROAD", "access=yes",
                                     "vehicle=no", "motorcar=yes", "motor_vehicle=no" }), })
     private Atlas carAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with car access
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_7)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_8)), },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_7)),
+                    @Node(coordinates = @Loc(value = TEST_8)), },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = TEST_1),
-                            @TestAtlas.Loc(value = TEST_3) }, tags = { "highway=STEPS",
-                                    "access=yes", "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1001000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3), @TestAtlas.Loc(value = TEST_4),
-                            @TestAtlas.Loc(value = TEST_5) }, tags = { "highway=STEPS",
+                    @Edge(id = "1007000001", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_3) }, tags = { "highway=STEPS", "access=yes",
+                                    "vehicle=yes" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = { "highway=STEPS",
                                     "access=yes", "motorcar=yes" }),
-                    @TestAtlas.Edge(id = "1002000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5), @TestAtlas.Loc(value = TEST_6),
-                            @TestAtlas.Loc(value = TEST_7) }, tags = { "highway=STEPS",
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6), @Loc(value = TEST_7) }, tags = { "highway=STEPS",
                                     "access=yes", "motor_vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1008000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motor_vehicle=yes", "vehicle=no" }),
-                    @TestAtlas.Edge(id = "1009000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_8) }, tags = { "highway=SERVICE",
-                                    "access=yes", "vehicle=yes", "motorcar=yes", "bus=yes",
+                    @Edge(id = "1008000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_8) }, tags = { "highway=FOOTWAY", "access=yes",
+                                    "motor_vehicle=yes", "vehicle=no" }),
+                    @Edge(id = "1009000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_8) }, tags = { "highway=SERVICE", "access=yes",
+                                    "vehicle=yes", "motorcar=yes", "bus=yes",
                                     "motor_vehicle=no" }), })
     private Atlas carAccessMetricHighwayAtlas;
     // Atlas to test designated use edges that are car navigable
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)), },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_2)), },
 
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=MOTORWAY", "access=yes", "vehicle=no", "minibus=yes" }),
-                    @TestAtlas.Edge(id = "1001000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3),
-                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=MOTORWAY", "access=yes",
+                                    "vehicle=no", "minibus=yes" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
                                     "motorcar=no", "minibus=yes" }),
-                    @TestAtlas.Edge(id = "1002000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=no", "minibus=yes" }), })
     private Atlas designatedUseCarNavigableAtlas;
     // Atlas to test car navigable edges with non-car access
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_10)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_9)),
+                    @Node(coordinates = @Loc(value = TEST_12)) },
 
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=MOTORWAY", "access=yes", "vehicle=no" }),
-                    @TestAtlas.Edge(id = "1001000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3),
-                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=MOTORWAY", "access=yes",
+                                    "vehicle=no" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=ROAD", "access=yes",
                                     "motorcar=no" }),
-                    @TestAtlas.Edge(id = "1002000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=no" }),
-                    @TestAtlas.Edge(id = "1004000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_9),
-                            @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=ROAD",
-                                    "access=yes", "motorcar=no", "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1006000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_12),
-                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1004000001", coordinates = { @Loc(value = TEST_9),
+                            @Loc(value = TEST_10) }, tags = { "highway=ROAD", "access=yes",
+                                    "motorcar=no", "vehicle=yes" }),
+                    @Edge(id = "1006000001", coordinates = { @Loc(value = TEST_12),
+                            @Loc(value = TEST_6) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=no", "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1007000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_12),
-                            @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
+                    @Edge(id = "1007000001", coordinates = { @Loc(value = TEST_12),
+                            @Loc(value = TEST_9) }, tags = { "highway=ROAD", "access=yes",
                                     "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessCarNavigableAtlas;
     // Atlas to test non-car navigable edges with non-car access
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_5)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_4)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_6)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_10)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_2)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_9)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = TEST_12)) },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_10)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_9)),
+                    @Node(coordinates = @Loc(value = TEST_12)) },
 
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = TEST_1), @TestAtlas.Loc(value = TEST_2) }, tags = {
-                            "highway=FOOTWAY", "access=yes", "vehicle=no" }),
-                    @TestAtlas.Edge(id = "1001000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_3),
-                            @TestAtlas.Loc(value = TEST_4) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motorcar=no" }),
-                    @TestAtlas.Edge(id = "1002000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_5),
-                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=FOOTWAY",
-                                    "access=yes", "motor_vehicle=no" }),
-                    @TestAtlas.Edge(id = "1004000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_9),
-                            @TestAtlas.Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY",
-                                    "access=yes", "motorcar=no", "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1006000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_12),
-                            @TestAtlas.Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=FOOTWAY", "access=yes",
+                                    "vehicle=no" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=FOOTWAY", "access=yes",
+                                    "motorcar=no" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=FOOTWAY", "access=yes",
+                                    "motor_vehicle=no" }),
+                    @Edge(id = "1004000001", coordinates = { @Loc(value = TEST_9),
+                            @Loc(value = TEST_10) }, tags = { "highway=CYCLEWAY", "access=yes",
+                                    "motorcar=no", "vehicle=yes" }),
+                    @Edge(id = "1006000001", coordinates = { @Loc(value = TEST_12),
+                            @Loc(value = TEST_6) }, tags = { "highway=PATH", "access=yes",
                                     "motor_vehicle=no", "vehicle=yes" }),
-                    @TestAtlas.Edge(id = "1007000001", coordinates = {
-                            @TestAtlas.Loc(value = TEST_12),
-                            @TestAtlas.Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN",
-                                    "access=yes", "motor_vehicle=yes", "motorcar=no" }), })
+                    @Edge(id = "1007000001", coordinates = { @Loc(value = TEST_12),
+                            @Loc(value = TEST_9) }, tags = { "highway=PEDESTRIAN", "access=yes",
+                                    "motor_vehicle=yes", "motorcar=no" }), })
     private Atlas nonCarAccessMetricHighwayAtlas;
 
     public Atlas carAccessCarNavigableAtlas()


### PR DESCRIPTION
This PR adds `ConflictingCarAccessibilityCheck` to flag roads with conflicting tag combinations resulting from combining car-navigable/non-car-navigable highway with different modes of transportation tags and access tag. This check flags the following tag combinations:
1. Car-navigable way with restricted car access having no designated vehicle tags like Motorcycle tag, Bus tag etc.
2. Car-navigable way with restricted car access having `Access`=`YES` tag and has designated vehicle tags.
3. Non-car-navigable way with open car access.

**Live Example**
1. The way [id:27605010](https://www.openstreetmap.org/way/27605010) has conflicting values between highway tag (highway=PATH) and motorcar tag values (motorcar=YES), which allows a car to drive. Normally, highway=PATH represents no access for cars and this tag combination is an example for non-car navigable highway with car access.
2. The way [id:409750479](https://www.openstreetmap.org/way/409750479) has conflicting values between highway tag (highway=SERVICE) and motorcar tag values (motorcar=NO), which prohibits cars to drive. The only transportation that is allowed here is the motorcycle which makes it a designated highway and so the access tag value should have been equal to NO instead of YES.
3. The way [id:369590090](https://www.openstreetmap.org/way/369590090) has conflicting values between highway tag (highway=RESIDENTIAL) and vehicle tag values (vehicle=NO), which prohibits cars to drive. It has bicycle=DESIGNATED tag to allow bicycles to use this road segment, which is conflicting with the highway tag value.