### PR TITLE
Floating Edge Check - Add Minimum Highway Type

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -94,7 +94,7 @@
     }
   },
   "FloatingEdgeCheck": {
-    "highway.minimum": "raceway",
+    "highway.minimum": "service",
     "length": {
       "maximum.kilometers": 100.0,
       "minimum.meters": 100.0

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -94,6 +94,7 @@
     }
   },
   "FloatingEdgeCheck": {
+    "minimum.highway.type": "raceway",
     "length": {
       "maximum.kilometers": 100.0,
       "minimum.meters": 100.0

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -94,7 +94,7 @@
     }
   },
   "FloatingEdgeCheck": {
-    "minimum.highway.type": "raceway",
+    "highway.minimum": "raceway",
     "length": {
       "maximum.kilometers": 100.0,
       "minimum.meters": 100.0

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -43,7 +43,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     // class variable to store the minimum distance for the floating road
     private final Distance minimumDistance;
     // The default value for the minimum highway type
-    private static final String HIGHWAY_MINIMUM_DEFAULT = HighwayTag.RACEWAY.toString();
+    private static final String HIGHWAY_MINIMUM_DEFAULT = HighwayTag.SERVICE.toString();
     private final HighwayTag highwayMinimum;
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -42,6 +42,9 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     private final Distance maximumDistance;
     // class variable to store the minimum distance for the floating road
     private final Distance minimumDistance;
+    // The default value for the minimum highway type
+    private static final String MINIMUM_HIGHWAY_TYPE_DEFAULT = HighwayTag.RACEWAY.toString();
+    private final HighwayTag minimumHighwayType;
 
     /**
      * Default constructor defined by the {@link BaseCheck} required to instantiate the Check within
@@ -67,6 +70,10 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
         this.maximumDistance = configurationValue(configuration, "length.maximum.kilometers",
                 DISTANCE_MAXIMUM_KILOMETERS_DEFAULT, Distance::kilometers);
+        // This retrieves the minimum highway type from the config
+        final String highwayType = this.configurationValue(configuration, "minimum.highway.type",
+                MINIMUM_HIGHWAY_TYPE_DEFAULT);
+        this.minimumHighwayType = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
     }
 
     /**
@@ -86,7 +93,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     {
         // Consider navigable master edges
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
-                && HighwayTag.isCarNavigableHighway(object);
+                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
     }
 
     /**
@@ -161,5 +168,22 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     {
         return !(SyntheticBoundaryNodeTag.isBoundaryNode(edge.start())
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.end()));
+    }
+
+    /**
+     * Checks if highway tag of given {@link AtlasObject} is of greater or equal priority than the
+     * minimum highway type given in the configurable. If no value is given in configurable, the
+     * default highway type of "RACEWAY" will be set as minimum.
+     *
+     * @param object
+     *            an {@link AtlasObject}
+     * @return {@code true} if the highway tag of this object is greater than or equal to the
+     *         minimum type
+     */
+    private boolean isMinimumHighwayType(final AtlasObject object)
+    {
+        final Optional<HighwayTag> highwayTagOfObject = HighwayTag.highwayTag(object);
+        return highwayTagOfObject.isPresent()
+                && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -173,7 +173,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     /**
      * Checks if highway tag of given {@link AtlasObject} is of greater or equal priority than the
      * minimum highway type given in the configurable. If no value is given in configurable, the
-     * default highway type of "RACEWAY" will be set as minimum.
+     * default highway type of "SERVICE" will be set as minimum.
      *
      * @param object
      *            an {@link AtlasObject}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -43,8 +43,8 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     // class variable to store the minimum distance for the floating road
     private final Distance minimumDistance;
     // The default value for the minimum highway type
-    private static final String MINIMUM_HIGHWAY_TYPE_DEFAULT = HighwayTag.RACEWAY.toString();
-    private final HighwayTag minimumHighwayType;
+    private static final String HIGHWAY_MINIMUM_DEFAULT = HighwayTag.RACEWAY.toString();
+    private final HighwayTag highwayMinimum;
 
     /**
      * Default constructor defined by the {@link BaseCheck} required to instantiate the Check within
@@ -71,9 +71,9 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
         this.maximumDistance = configurationValue(configuration, "length.maximum.kilometers",
                 DISTANCE_MAXIMUM_KILOMETERS_DEFAULT, Distance::kilometers);
         // This retrieves the minimum highway type from the config
-        final String highwayType = this.configurationValue(configuration, "minimum.highway.type",
-                MINIMUM_HIGHWAY_TYPE_DEFAULT);
-        this.minimumHighwayType = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
+        final String highwayType = this.configurationValue(configuration, "highway.minimum",
+                HIGHWAY_MINIMUM_DEFAULT);
+        this.highwayMinimum = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
     }
 
     /**
@@ -184,6 +184,6 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     {
         final Optional<HighwayTag> highwayTagOfObject = HighwayTag.highwayTag(object);
         return highwayTagOfObject.isPresent()
-                && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+                && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.highwayMinimum);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -18,9 +18,9 @@ public class FloatingEdgeCheckTest
     private FloatingEdgeCheck check = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"FloatingEdgeCheck\":{\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
-    private FloatingEdgeCheck check2 = new FloatingEdgeCheck(
+    private FloatingEdgeCheck minimumHighwayCheck = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"FloatingEdgeCheck\":{\"minimum.highway.type\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
+                    "{\"FloatingEdgeCheck\":{\"highway.minimum\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
 
     @Test
     public void testBidirectionalFloatingEdge()
@@ -63,7 +63,7 @@ public class FloatingEdgeCheckTest
     @Test
     public void testInlineConfigFloatingEdge()
     {
-        this.verifier.actual(this.setup.floatingEdgeAtlas(), check2);
+        this.verifier.actual(this.setup.floatingEdgeAtlas(), minimumHighwayCheck);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -18,6 +18,9 @@ public class FloatingEdgeCheckTest
     private FloatingEdgeCheck check = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"FloatingEdgeCheck\":{\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
+    private FloatingEdgeCheck check2 = new FloatingEdgeCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"FloatingEdgeCheck\":{\"minimum.highway.type\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
 
     @Test
     public void testBidirectionalFloatingEdge()
@@ -57,4 +60,10 @@ public class FloatingEdgeCheckTest
         this.verifier.verifyEmpty();
     }
 
+    @Test
+    public void testInlineConfigFloatingEdge()
+    {
+        this.verifier.actual(this.setup.floatingEdgeAtlas(), check2);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
 }


### PR DESCRIPTION
This PR adds a value - `minimum highway type` in the configurable. All the highway tags that have lower priority than the set minimum highway type will not be considered for the check. If no value is given in the configuration file, then the default type of `Highway = SERVICE` will be set as minimum.