### PR TITLE
Self Intersecting Polyline Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -256,7 +256,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
+    "minimum.highway.type":"service",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -256,6 +256,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
+    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
     "minimum.highway.type":"service",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -64,7 +64,6 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
         // Retrieve minimum highway type from the config
         this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_TYPE_DEFAULT, string -> HighwayTag.valueOf(string.toUpperCase()));
-
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -39,6 +39,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     private static final String AREA_INSTRUCTION = "Feature {0,number,#} has invalid geometry at {1}";
     private static final String POLYLINE_BUILDING_INSTRUCTION = "Feature {0,number,#} is a incomplete "
             + "building at {1}";
+
     private static final String DUPLICATE_EDGE_INSTRUCTION = "Feature {0,number,#} has a duplicate "
             + "Edge at {1}";
     private static final String POLYLINE_INSTRUCTION = "Self-intersecting polyline for feature "

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -125,9 +125,17 @@ public class SelfIntersectingPolyLineCheckTest
     }
 
     @Test
-    public void testMinimumHighwayType()
+    public void testHighPriorityEdgeIntersection()
     {
         this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), minimumHighwayCheck);
         this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testLowPriorityEdgeIntersection()
+    {
+        this.verifier.actual(this.setup.getLowPriorityInvalidEdgeIntersection(),
+                minimumHighwayCheck);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -9,11 +9,13 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * {@link SelfIntersectingPolylineCheck} unit test
  *
  * @author mgostintsev
+ * @author sayas01
  */
 public class SelfIntersectingPolyLineCheckTest
 {
     private final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
-            ConfigurationResolver.emptyConfiguration());
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"SelfIntersectingPolylineCheck\":{\"tags.filter\":\"highway->!proposed&highway->!construction&highway->!footway&highway->!path\"}}"));
     private final SelfIntersectingPolylineCheck minimumHighwayCheck = new SelfIntersectingPolylineCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"SelfIntersectingPolylineCheck\":{\"minimum.highway.type\":\"service\"}}"));
@@ -56,7 +58,7 @@ public class SelfIntersectingPolyLineCheckTest
     public void testInvalidLineGeometryHighwayFootwayTag()
     {
         this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), check);
-        this.verifier.verifyExpectedSize(1);
+        this.verifier.verifyExpectedSize(0);
     }
 
     @Test
@@ -123,7 +125,7 @@ public class SelfIntersectingPolyLineCheckTest
     }
 
     @Test
-    public void testInlineConfig()
+    public void testMinimumHighwayType()
     {
         this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), minimumHighwayCheck);
         this.verifier.verifyExpectedSize(1);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -13,8 +13,10 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 public class SelfIntersectingPolyLineCheckTest
 {
     private final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
+            ConfigurationResolver.emptyConfiguration());
+    private final SelfIntersectingPolylineCheck minimumHighwayCheck = new SelfIntersectingPolylineCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"SelfIntersectingPolylineCheck\":{\"tags.filter\":\"highway->!proposed&highway->!construction&highway->!footway&highway->!path\"}}"));
+                    "{\"SelfIntersectingPolylineCheck\":{\"minimum.highway.type\":\"service\"}}"));
 
     @Rule
     public SelfIntersectingPolylineTestCaseRule setup = new SelfIntersectingPolylineTestCaseRule();
@@ -54,7 +56,7 @@ public class SelfIntersectingPolyLineCheckTest
     public void testInvalidLineGeometryHighwayFootwayTag()
     {
         this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), check);
-        this.verifier.verifyExpectedSize(0);
+        this.verifier.verifyExpectedSize(1);
     }
 
     @Test
@@ -117,6 +119,13 @@ public class SelfIntersectingPolyLineCheckTest
     public void testInvalidAreaBuildTag()
     {
         this.verifier.actual(this.setup.getInvalidAreaBuildingTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInlineConfig()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), minimumHighwayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
@@ -167,6 +167,16 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
                             @Loc(value = ONE) }, tags = { "building=yes" }) })
     private Atlas invalidAreaBuildingTag;
 
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)),
+            @Node(id = "5", coordinates = @Loc(value = FIVE)) }, edges = {
+                    @Edge(id = INVALID_EDGE_ID_2, coordinates = { @Loc(value = ONE),
+                            @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=track" }) })
+    private Atlas lowPriorityInvalidEdgeIntersection;
+
     public Atlas getValidLineNoSelfIntersection()
     {
         return this.validLineNoSelfIntersection;
@@ -235,5 +245,10 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
     public Atlas getInvalidAreaBuildingTag()
     {
         return this.invalidAreaBuildingTag;
+    }
+
+    public Atlas getLowPriorityInvalidEdgeIntersection()
+    {
+        return this.lowPriorityInvalidEdgeIntersection;
     }
 }


### PR DESCRIPTION
### Description:

This PR adds a minimum highway type to existing SelfIntersectingPolyLineCheck.  The enhancement simply adds a `minimum.highway.filter` with a default value of `highway=service` to the config. Valid edges for the check will now be checked for  highway tags with equal or higher priority than the config value.

### Potential Impact:

None

### Unit Test Approach:

Added a single unit test to test the inline config value.

### Test Results:

NA

