### PR TITLE
Relations Support for CheckFlag using Updated Atlas-Checks Method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -105,9 +105,7 @@ public final class CheckFlagEvent extends Event
                 feature.addProperty(TYPE, "Feature");
             }
             // Get flagged relations as GeoJson features
-            final List<JsonObject> flaggedRelationFeatures = flaggedRelations.stream()
-                    .map(flaggedRelation -> flaggedRelation.asGeoJsonFeature(flag.getIdentifier()))
-                    .collect(Collectors.toList());
+            final List<JsonObject> flaggedRelationFeatures = getFlaggedRelationsGeojsonFeatures(flag);
             if (flaggedRelations.size() == 1 && !feature.has(GEOMETRY))
             {
                 feature.add(GEOMETRY, flaggedRelationFeatures.get(0).get(GEOMETRY));
@@ -121,6 +119,7 @@ public final class CheckFlagEvent extends Event
             }
             // To geometries of flagged objects add geometries of flaggedRelation
             geometriesJsonArray.addAll(populateFlaggedRelationGeometries(flaggedRelationFeatures));
+            // To properties of flagged objects add properties of flaggedRelation
             featureProperties
                     .addAll(populateFlaggedRelationFeatureProperties(flaggedRelationFeatures));
             featureOsmIds.addAll(populateFlaggedRelationFeatureOsmIds(flaggedRelationFeatures));
@@ -143,6 +142,19 @@ public final class CheckFlagEvent extends Event
         feature.addProperty("id", flag.getIdentifier());
         feature.add("properties", flagProperties);
         return feature;
+    }
+
+    /**
+     * Converts all {@link FlaggedRelation} to geojson feature
+     *
+     * @param flag CheckFlag
+     * @return {@link List<JsonObject>} corresponding to geojson feature of {@link FlaggedRelation}
+     */
+    private static List<JsonObject> getFlaggedRelationsGeojsonFeatures(final CheckFlag flag)
+    {
+        return flag.getFlaggedRelations().stream()
+                .map(flaggedRelation -> flaggedRelation.asGeoJsonFeature(flag.getIdentifier()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -101,6 +101,7 @@ public final class CheckFlagEvent extends Event
             feature = new JsonObject();
             geometriesJsonArray = new JsonArray();
         }
+
         if (!flaggedRelations.isEmpty())
         {
             if (!feature.has(TYPE))

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -62,11 +62,11 @@ public final class CheckFlagEvent extends Event
         // Add additional properties
         additionalProperties.forEach(flagProperties::addProperty);
 
-        JsonObject feature = new JsonObject();
+        final JsonObject feature;
         final List<GeometryWithProperties> geometriesWithProperties = flag
-                .getLocationIterableProperties();
+                .getGeometryWithProperties();
         final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();
-        JsonArray geometriesJsonArray = new JsonArray();
+        final JsonArray geometriesJsonArray;
         final JsonArray featureProperties = new JsonArray();
         final Set<JsonElement> featureOsmIds = new HashSet<>();
         if (!geometriesWithProperties.isEmpty())
@@ -94,7 +94,11 @@ public final class CheckFlagEvent extends Event
                         Optional.ofNullable(properties.get("osmid")).ifPresent(featureOsmIds::add);
                     }));
         }
-
+        else
+        {
+            feature = new JsonObject();
+            geometriesJsonArray = new JsonArray();
+        }
         if (!flaggedRelations.isEmpty())
         {
             final JsonArray geometriesOfFlaggedRelations = new JsonArray();
@@ -172,7 +176,7 @@ public final class CheckFlagEvent extends Event
         if (!flag.getFlaggedObjects().isEmpty())
         {
             flagJson = GEOJSON_BUILDER
-                    .createFromGeometriesWithProperties(flag.getLocationIterableProperties())
+                    .createFromGeometriesWithProperties(flag.getGeometryWithProperties())
                     .jsonObject();
         }
         final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -114,7 +114,7 @@ public final class CheckFlagEvent extends Event
             {
                 feature.add(GEOMETRY, flaggedRelationFeatures.get(0).get(GEOMETRY));
             }
-            else if (!feature.has(GEOMETRY_COLLECTION))
+            else if (flaggedRelations.size() != 1 && !feature.has(GEOMETRY))
             {
                 final JsonObject geometryCollection = new JsonObject();
                 geometryCollection.add(GEOMETRIES, geometriesJsonArray);

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -101,7 +101,6 @@ public final class CheckFlagEvent extends Event
             feature = new JsonObject();
             geometriesJsonArray = new JsonArray();
         }
-
         if (!flaggedRelations.isEmpty())
         {
             if (!feature.has(TYPE))

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -100,7 +100,7 @@ public final class CheckFlagEvent extends Event
             final JsonArray geometriesOfFlaggedRelations = new JsonArray();
             if (!feature.has(TYPE))
             {
-                feature.addProperty(TYPE, "feature");
+                feature.addProperty(TYPE, "Feature");
             }
             // Get flagged relations as GeoJson features
             final List<JsonObject> flaggedRelationFeatures = flaggedRelations.stream()

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.checks.event;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -14,8 +13,6 @@ import org.openstreetmap.atlas.checks.base.Check;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.flag.FlaggedObject;
 import org.openstreetmap.atlas.checks.flag.FlaggedRelation;
-import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.GeometryWithProperties;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonObject;
@@ -35,6 +32,12 @@ import com.google.gson.JsonPrimitive;
 public final class CheckFlagEvent extends Event
 {
     private static final GeoJsonBuilder GEOJSON_BUILDER = new GeoJsonBuilder();
+    private static final String GEOMETRY = "geometry";
+    private static final String GEOMETRIES = "geometries";
+    private static final String PROPERTIES = "properties";
+    private static final String FEATURES = "features";
+    private static final String TYPE = "type";
+    private static final String FEATURE_COLLECTION = "FeatureCollection";
 
     private final String checkName;
     private final CheckFlag flag;
@@ -58,58 +61,60 @@ public final class CheckFlagEvent extends Event
         // Add additional properties
         additionalProperties.forEach(flagProperties::addProperty);
 
-        final JsonObject feature;
-        final List<GeometryWithProperties> geometriesWithProperties = flag.getLocationIterableProperties();
-        if (geometriesWithProperties.size() == 1)
-        {
-            feature = GEOJSON_BUILDER.create(geometriesWithProperties.get(0));
-        }
-        else
-        {
-            feature = GEOJSON_BUILDER.createGeometryCollectionFeature(geometriesWithProperties)
-                    .jsonObject();
-        }
-        // Geometry json element of feature : "type":"feature", "geometry":{"type":"GeometryCoolection","geometries":[type and coordinates]
-        // first geometry
-        final JsonElement geometryCollection = feature.get("geometry");
-        // To access geometries of jsonObject geometry
-        final JsonObject asJsonObject = geometryCollection.getAsJsonObject();
-        // Second geometries with coordinates
-        final JsonArray geometriesJsonArray = asJsonObject.getAsJsonArray("geometries");
-
-
-
+        JsonObject feature = new JsonObject();
+        final List<GeometryWithProperties> geometriesWithProperties = flag
+                .getLocationIterableProperties();
+        final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();
+        JsonArray geometriesJsonArray = new JsonArray();
         final JsonArray featureProperties = new JsonArray();
         final Set<JsonElement> featureOsmIds = new HashSet<>();
-        geometriesWithProperties.stream().forEach(
-                geometry -> Optional.ofNullable(geometry.getProperties()).ifPresent(propertyMap ->
-                {
-                    final JsonObject properties = new JsonObject();
-                    propertyMap.forEach( (key, value) -> properties.addProperty(key, (String) value));
-                    featureProperties.add(properties);
-
-                    Optional.ofNullable(properties.get("osmid")).ifPresent(featureOsmIds::add);
-                }));
-
-        if(!flag.getFlaggedRelations().isEmpty())
+        if (!geometriesWithProperties.isEmpty())
         {
-            final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();
+            if (geometriesWithProperties.size() + flaggedRelations.size() == 1)
+            {
+                feature = GEOJSON_BUILDER.create(geometriesWithProperties.get(0));
+            }
+            else
+            {
+                feature = GEOJSON_BUILDER.createGeometryCollectionFeature(geometriesWithProperties)
+                        .jsonObject();
+            }
+            // Geometries with coordinates
+            geometriesJsonArray = feature.get(GEOMETRY).getAsJsonObject()
+                    .getAsJsonArray(GEOMETRIES);
+            geometriesWithProperties.stream().forEach(geometry -> Optional
+                    .ofNullable(geometry.getProperties()).ifPresent(propertyMap ->
+                    {
+                        final JsonObject properties = new JsonObject();
+                        propertyMap.forEach(
+                                (key, value) -> properties.addProperty(key, (String) value));
+                        featureProperties.add(properties);
+
+                        Optional.ofNullable(properties.get("osmid")).ifPresent(featureOsmIds::add);
+                    }));
+        }
+
+        if (!flaggedRelations.isEmpty())
+        {
             final List<JsonObject> flaggedRelationFeatures = flaggedRelations.stream()
                     .map(flaggedRelation -> flaggedRelation.asGeoJsonFeature(flag.getIdentifier()))
                     .collect(Collectors.toList());
-            // add all geometries of flaggedRelations to the json array
+            // Add all geometries of flaggedRelations to the json array
             final JsonArray geometriesOfFlaggedRelations = new JsonArray();
             flaggedRelationFeatures.stream()
-                    .map(flaggedRelationFeature -> flaggedRelationFeature.get("geometry"))
+                    .map(flaggedRelationFeature -> flaggedRelationFeature.get(GEOMETRY))
                     .forEach(jsonElement -> geometriesOfFlaggedRelations.add(jsonElement));
 
             // To geometries of flagged objects add geometries of flaggedRelation
             geometriesJsonArray.addAll(geometriesOfFlaggedRelations);
             flaggedRelationFeatures.stream()
-                    .map(flaggedRelationFeature -> flaggedRelationFeature.get("properties"))
+                    .map(flaggedRelationFeature -> flaggedRelationFeature.get(PROPERTIES))
                     .forEach(property -> featureProperties.add(property));
+            // Add osm id
             flaggedRelationFeatures.stream()
-                    .map(flaggedRelationFeature -> flaggedRelationFeature.get("properties")).map(jsonElement -> jsonElement.getAsJsonObject().get("osmIdentifier")).forEach(featureOsmIds::add);
+                    .map(flaggedRelationFeature -> flaggedRelationFeature.get(PROPERTIES))
+                    .map(jsonElement -> jsonElement.getAsJsonObject().get("osmIdentifier"))
+                    .forEach(featureOsmIds::add);
         }
 
         final JsonArray uniqueFeatureOsmIds = new JsonArray();
@@ -131,136 +136,6 @@ public final class CheckFlagEvent extends Event
         feature.add("properties", flagProperties);
         return feature;
     }
-//    /**
-//     * Populates properties of flaggedRelations. Both the relation properties as well as its member
-//     * properties will be populated.
-//     *
-//     * @param flag
-//     * @param geometriesWithProperties
-//     * @param featureOsmIds
-//     * @param featureProperties
-//     */
-//    private static void populateFlaggedRelationProperties(final CheckFlag flag,
-//            final List<GeometryWithProperties> geometriesWithProperties,
-//            final Set<JsonElement> featureOsmIds, final JsonArray featureProperties)
-//    {
-//        final Iterator<FlaggedRelation> iterator = flag.getFlaggedRelations().iterator();
-//        while (iterator.hasNext())
-//        {
-//            final JsonObject relationProperties = new JsonObject();
-//            final JsonObject innerRelationProperties = new JsonObject();
-//            final Set<Long> flaggedMemberOSMIds = new HashSet<>();
-//            final FlaggedRelation next = iterator.next();
-//            // Populate flagged relation properties
-//            next.getProperties().forEach(relationProperties::addProperty);
-//            featureProperties.add(relationProperties);
-//            // If the flagged relations have relations as members, then add the properties of the
-//            // member relations as well.
-//            // Get all members of the relation that are relations
-//            final List<RelationMember> innerRelations = next.members().stream()
-//                    .filter(member -> member.getEntity() instanceof Relation)
-//                    .collect(Collectors.toList());
-//            if (!innerRelations.isEmpty())
-//            {
-//                // Get properties of the member relation
-//                innerRelations.stream()
-//                        .map(relationMember -> new FlaggedRelation(
-//                                (Relation) relationMember.getEntity()).getProperties())
-//                        // Populate the properties of the member relations
-//                        .forEach(map -> map.forEach(innerRelationProperties::addProperty));
-//                featureProperties.add(innerRelationProperties);
-//            }
-//            // Set of relation member OSM IDs
-//            final Set<Long> relationMemberOsmIds = next.members().stream()
-//                    .map(member -> member.getEntity().getOsmIdentifier())
-//                    .collect(Collectors.toSet());
-//            // Populate properties of members
-//            populateMemberProperties(geometriesWithProperties, featureOsmIds, featureProperties,
-//                    flaggedMemberOSMIds, relationMemberOsmIds);
-//            Optional.ofNullable(relationProperties.get("osmid")).ifPresent(featureOsmIds::add);
-//            Optional.ofNullable(innerRelationProperties.get("osmid")).ifPresent(featureOsmIds::add);
-//        }
-//    }
-
-    /**
-     * Populate properties of flagged objects
-     *
-     * @param geometriesWithProperties
-     * @param featureOsmIds
-     * @param featureProperties
-     */
-    private static void populateFlaggedObjectProperties(
-            final List<GeometryWithProperties> geometriesWithProperties,
-            final Set<JsonElement> featureOsmIds, final JsonArray featureProperties)
-    {
-        geometriesWithProperties.stream().forEach(geometryWithProperties -> Optional
-                .ofNullable(geometryWithProperties.getProperties()).ifPresent(propertyMap ->
-                {
-                    final JsonObject properties = new JsonObject();
-                    // Consider only those geometriesWithProperties that are not members/flattened
-                    // members of relations
-                    if (!propertyMap.containsKey("roles"))
-                    {
-                        propertyMap.forEach(
-                                (key, value) -> properties.addProperty(key, (String) value));
-                        featureProperties.add(properties);
-                        Optional.ofNullable(properties.get("osmid")).ifPresent(featureOsmIds::add);
-                    }
-
-                }));
-    }
-
-    /**
-     * Populate properties of relation members. Note: @param geometries has geometries of all
-     * flattened members. Properties will be populated from the list of geometries of relation
-     * members only. This makes sure that the duplicate properties of way sectioned edges are not
-     * added. Eg: if a way in OSM has five edges in Atlas, then the geometry of all the five edges
-     * will be added but only the properties of one of these.
-     *
-     * @param geometriesWithProperties
-     * @param featureOsmIds
-     * @param featureProperties
-     * @param relationMemberOsmIds
-     * @param flaggedMemberOSMIds
-     */
-    private static void populateMemberProperties(
-            final List<GeometryWithProperties> geometriesWithProperties,
-            final Set<JsonElement> featureOsmIds, final JsonArray featureProperties,
-            final Set<Long> flaggedMemberOSMIds, final Set<Long> relationMemberOsmIds)
-    {
-        geometriesWithProperties.stream()
-                .filter(geometryWithProperties -> Optional
-                        .ofNullable(geometryWithProperties.getProperties()).isPresent())
-                .map(geometryWithProperties -> geometryWithProperties.getProperties())
-                .forEach(propertyMap ->
-                {
-                    final Long osmid = Long.valueOf((String) propertyMap.get("osmid"));
-                    // For each geometry, add properties for only the members of the relation.
-                    // This ensures that the same properties of way sectioned edges are not
-                    // duplicated. Also, only relation member properties are added and not
-                    // properties
-                    // of all flattened members.
-                    if (!flaggedMemberOSMIds.contains(osmid)
-                            && relationMemberOsmIds.contains(osmid))
-                    {
-                        final JsonObject properties = new JsonObject();
-                        propertyMap.forEach((key, value) ->
-                        {
-                            if (key.contains("roles"))
-                            {
-                                properties.add(key, (JsonElement) value);
-                            }
-                            else
-                            {
-                                properties.addProperty(key, (String) value);
-                            }
-                        });
-                        featureProperties.add(properties);
-                        Optional.ofNullable(properties.get("osmid")).ifPresent(featureOsmIds::add);
-                        flaggedMemberOSMIds.add(osmid);
-                    }
-                });
-    }
 
     /**
      * Converts given {@link CheckFlag} to {@link JsonObject} with additional key-value parameters
@@ -275,34 +150,44 @@ public final class CheckFlagEvent extends Event
     public static JsonObject flagToJson(final CheckFlag flag,
             final Map<String, String> additionalProperties)
     {
-        final JsonObject flagJson = GEOJSON_BUILDER.createFromGeometriesWithProperties(flag.getLocationIterableProperties())
-                .jsonObject();
+        JsonObject flagJson = new JsonObject();
+        if (!flag.getFlaggedObjects().isEmpty())
+        {
+            flagJson = GEOJSON_BUILDER
+                    .createFromGeometriesWithProperties(flag.getLocationIterableProperties())
+                    .jsonObject();
+        }
+        final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();
+        // Add features of FlaggedRelation if any
+        if (!flaggedRelations.isEmpty())
+        {
+            // Add type feature collection if not already set.
+            if (!flagJson.has(FEATURES))
+            {
+                flagJson.addProperty(TYPE, FEATURE_COLLECTION);
+                flagJson.add(FEATURES, new JsonArray());
+            }
+            final JsonArray features = flagJson.getAsJsonArray(FEATURES);
+            // Get features of each flaggedRelations and add it to the flagJson object's FEATURES
+            // element
+            flaggedRelations.stream()
+                    .map(flaggedRelation -> flaggedRelation.asGeoJsonFeature(flag.getIdentifier()))
+                    .forEach(jsonObject -> features.add(jsonObject));
+        }
         final JsonObject flagPropertiesJson = new JsonObject();
         flagPropertiesJson.addProperty("id", flag.getIdentifier());
         flagPropertiesJson.addProperty("instructions", flag.getInstructions());
 
         // Add additional properties
-        additionalProperties.forEach((key, value) -> flagPropertiesJson.addProperty(key, value));
-        // Add relation properties of the flaggedRelation to all its members.
-        // If relations are not flagged then the list is empty and no action will be taken.
-        final Set<FlaggedRelation> flaggedRelations = flag.getFlaggedRelations();
-        if (!flaggedRelations.isEmpty())
-        {
-            final JsonArray relationsJson = new JsonArray();
-            flag.getFlaggedRelations().stream()
-                    .map(flaggedRelation -> flaggedRelation.getProperties()).forEach(properties ->
-            {
-                final JsonObject relationPropertiesJson = new JsonObject();
-                properties.forEach(relationPropertiesJson::addProperty);
-                final String osmid = properties.get("osmid");
-                relationsJson.add(relationPropertiesJson);
-            });
-            flagPropertiesJson.add("relations", relationsJson);
-        }
+        additionalProperties.forEach(flagPropertiesJson::addProperty);
 
         // Add properties to the previously generate geojson
         flagJson.add("properties", flagPropertiesJson);
         return flagJson;
+    }
+
+    private static void accept(final JsonObject jsonObject)
+    {
     }
 
     /**
@@ -404,9 +289,7 @@ public final class CheckFlagEvent extends Event
 
     public String asLineDelimitedGeoJsonFeatures()
     {
-        return asLineDelimitedGeoJsonFeatures((jsonObject) ->
-        {
-        });
+        return asLineDelimitedGeoJsonFeatures(CheckFlagEvent::accept);
     }
 
     public String asLineDelimitedGeoJsonFeatures(final Consumer<JsonObject> jsonMutator)

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -232,12 +232,11 @@ public final class CheckFlagEvent extends Event
     private static Set<JsonElement> populateFlaggedRelationFeatureOsmIds(
             final List<JsonObject> flaggedRelationFeatures)
     {
-        final Set<JsonElement> featureOsmIds = new HashSet<>();
         // Add osm id
-        flaggedRelationFeatures.stream().map(CheckFlagEvent::getFlaggedRelationPropertyFromFeature)
+        return flaggedRelationFeatures.stream()
+                .map(CheckFlagEvent::getFlaggedRelationPropertyFromFeature)
                 .map(jsonElement -> jsonElement.getAsJsonObject().get(OSM_IDENTIFIER))
-                .forEach(featureOsmIds::add);
-        return featureOsmIds;
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -119,8 +119,11 @@ public final class CheckFlagEvent extends Event
                 geometryCollection.addProperty(TYPE, GEOMETRY_COLLECTION);
                 feature.add(GEOMETRY, geometryCollection);
             }
-            populateFlaggedRelationPropertiesAndGeometries(flaggedRelationFeatures,
-                    geometriesJsonArray, featureOsmIds, featureProperties);
+            // To geometries of flagged objects add geometries of flaggedRelation
+            geometriesJsonArray.addAll(populateFlaggedRelationGeometries(flaggedRelationFeatures));
+            featureProperties
+                    .addAll(populateFlaggedRelationFeatureProperties(flaggedRelationFeatures));
+            featureOsmIds.addAll(populateFlaggedRelationFeatureOsmIds(flaggedRelationFeatures));
         }
         final JsonArray uniqueFeatureOsmIds = new JsonArray();
         featureOsmIds.forEach(uniqueFeatureOsmIds::add);
@@ -142,26 +145,59 @@ public final class CheckFlagEvent extends Event
         return feature;
     }
 
-    private static void populateFlaggedRelationPropertiesAndGeometries(
-            final List<JsonObject> flaggedRelationFeatures, final JsonArray geometriesJsonArray,
-            final Set<JsonElement> featureOsmIds, final JsonArray featureProperties)
+    /**
+     * Populates geometries of flaggedRelation features to a {@link JsonArray}
+     *
+     * @param flaggedRelationFeatures
+     *            geojson features of FlaggedRelations
+     * @return {@link JsonArray} of geometries of flaggedRelations
+     */
+    private static JsonArray populateFlaggedRelationGeometries(
+            final List<JsonObject> flaggedRelationFeatures)
     {
         final JsonArray geometriesOfFlaggedRelations = new JsonArray();
         // Add all geometries of flaggedRelations to the json array
         flaggedRelationFeatures.stream()
                 .map(flaggedRelationFeature -> flaggedRelationFeature.get(GEOMETRY))
                 .forEach(jsonElement -> geometriesOfFlaggedRelations.add(jsonElement));
-        // To geometries of flagged objects add geometries of flaggedRelation
-        geometriesJsonArray.addAll(geometriesOfFlaggedRelations);
+        return geometriesOfFlaggedRelations;
+    }
+
+    /**
+     * Populates properties of flaggedRelation features to a {@link JsonArray}
+     *
+     * @param flaggedRelationFeatures
+     *            geojson features of FlaggedRelations
+     * @return {@link JsonArray} of properties of flaggedRelations
+     */
+    private static JsonArray populateFlaggedRelationFeatureProperties(
+            final List<JsonObject> flaggedRelationFeatures)
+    {
+        final JsonArray featureProperties = new JsonArray();
         // Update feature properties from flaggedRelation features
         flaggedRelationFeatures.stream()
                 .map(flaggedRelationFeature -> flaggedRelationFeature.get(PROPERTIES))
                 .forEach(property -> featureProperties.add(property));
+        return featureProperties;
+    }
+
+    /**
+     * Populates osmids of flaggedRelation features to a {@link Set<JsonElement>}
+     *
+     * @param flaggedRelationFeatures
+     *            flaggedRelationFeatures geojson features of FlaggedRelations
+     * @return {@link Set<JsonElement>} of all osmids of flaggedRelations
+     */
+    private static Set<JsonElement> populateFlaggedRelationFeatureOsmIds(
+            final List<JsonObject> flaggedRelationFeatures)
+    {
+        final Set<JsonElement> featureOsmIds = new HashSet<>();
         // Add osm id
         flaggedRelationFeatures.stream()
                 .map(flaggedRelationFeature -> flaggedRelationFeature.get(PROPERTIES))
                 .map(jsonElement -> jsonElement.getAsJsonObject().get("osmIdentifier"))
                 .forEach(featureOsmIds::add);
+        return featureOsmIds;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -6,16 +6,13 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.checks.base.Check;
@@ -25,14 +22,10 @@ import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Rectangle;
-import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasItem;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
-import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
-import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
-import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.GeometryWithProperties;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonUtils;
@@ -341,65 +334,11 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public List<GeometryWithProperties> getLocationIterableProperties()
     {
-//        return Stream.concat(getListOfGeoJsonObjectsForFlaggedRelation().stream(),this.flaggedObjects.stream()
-//                .map(flaggedObject -> new GeoJsonBuilder.GeometryWithProperties(
-//                        flaggedObject.getGeometry(), new HashMap<>(flaggedObject.getProperties()))))
-//                .collect(Collectors.toList());
-        return this.flaggedObjects.stream().map(flaggedObject -> new GeoJsonBuilder.GeometryWithProperties
-                (flaggedObject.getGeometry(), new HashMap<>(flaggedObject.getProperties()))).collect(Collectors.toList());
+        return this.flaggedObjects.stream()
+                .map(flaggedObject -> new GeoJsonBuilder.GeometryWithProperties(
+                        flaggedObject.getGeometry(), new HashMap<>(flaggedObject.getProperties())))
+                .collect(Collectors.toList());
     }
-
-    /**
-     * Creates geojson objects for the members of the flagged relations.
-     *
-     * @return a list of {@link GeoJsonBuilder.GeometryWithProperties} representing all flagged geometries of
-     *         FlaggedRelation
-     */
-//    public List<GeometryWithProperties> getListOfGeoJsonObjectsForFlaggedRelation()
-//    {
-//        final List<GeometryWithProperties> locationIterablePropertyList = new ArrayList<>();
-//        final Iterator<FlaggedRelation> iterator = this.flaggedRelations.iterator();
-//        while (iterator.hasNext())
-//        {
-//
-//            // Get flattened members of relation as a RelationMemberList
-//            final RelationMemberList relationMembers = iterator.next()
-//                    .getFlattenedRelationMembers();
-//            for (final RelationMember relationMember : relationMembers)
-//            {
-//                final AtlasEntity entity = relationMember.getEntity();
-//                final Map<String, Object> flaggedObjectProperties = new HashMap<>();
-//                final JsonArray roles = new JsonArray();
-//                FlaggedObject flaggedObject = null;
-//
-//                if (entity instanceof LocationItem)
-//                {
-//                    final FlaggedPoint flaggedPoint = new FlaggedPoint((LocationItem) entity);
-//                    flaggedObjectProperties.putAll(flaggedPoint.getProperties());
-//                    flaggedObject = flaggedPoint;
-//                }
-//                // If edge, consider only the master edges
-//                else if (Edge.isMasterEdgeIdentifier(entity.getIdentifier()))
-//                {
-//                    final FlaggedPolyline flaggedPolyline = new FlaggedPolyline(entity);
-//                    flaggedObject = flaggedPolyline;
-//                    flaggedObjectProperties.putAll(flaggedPolyline.getProperties());
-//                }
-//                if (flaggedObject != null)
-//                {
-//                    final JsonObject roleDescription = new JsonObject();
-//                    // Add member role and relation identifier to the property map
-//                    roleDescription.addProperty("role", relationMember.getRole());
-//                    roleDescription.addProperty("part of", relationMember.getRelationIdentifier());
-//                    roles.add(roleDescription);
-//                    flaggedObjectProperties.put("roles", roles);
-//                    locationIterablePropertyList.add(new GeoJsonBuilder.GeometryWithProperties(
-//                            flaggedObject.getGeometry(), new HashMap<>(flaggedObjectProperties)));
-//                }
-//            }
-//        }
-//        return locationIterablePropertyList;
-//    }
 
     /**
      * Builds a MapRouletted {@link Task} from this {@link CheckFlag}

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -372,11 +372,20 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         }
 
         final JsonArray features = new JsonArray();
-        // Need to update with flaggedRelations as well
-        this.getGeometryWithProperties()
-                .forEach(shape -> features.add(new GeoJsonBuilder().create(shape)));
+        // Features
+        if (!this.getGeometryWithProperties().isEmpty())
+        {
+            this.getGeometryWithProperties()
+                    .forEach(shape -> features.add(new GeoJsonBuilder().create(shape)));
+        }
+        final Set<FlaggedObject> flaggedRelations = this.getFlaggedRelations();
+        if (!flaggedRelations.isEmpty())
+        {
+            this.getFlaggedRelations().stream()
+                    .map(flaggedRelation -> flaggedRelation.asGeoJsonFeature(identifier))
+                    .forEach(feature -> features.add(feature));
+        }
         task.setGeoJson(Optional.of(features));
-
         return task;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -36,6 +36,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterators;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
@@ -59,7 +60,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     private String challengeName = null;
     private final List<String> instructions = new ArrayList<>();
     private final Set<FlaggedObject> flaggedObjects = new LinkedHashSet<>();
-    private final Set<FlaggedRelation> flaggedRelations = new LinkedHashSet<>();
+    private final Set<FlaggedObject> flaggedRelations = new LinkedHashSet<>();
 
     /**
      * A basic constructor that simply flags some identifying value
@@ -254,7 +255,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         return Objects.equals(this.identifier, otherFlag.identifier)
                 && Objects.equals(this.challengeName, otherFlag.challengeName)
                 && Objects.equals(this.instructions, otherFlag.instructions)
-                && Objects.equals(this.flaggedObjects, otherFlag.flaggedObjects);
+                && Objects.equals(this.flaggedObjects, otherFlag.flaggedObjects)
+                && Objects.equals(this.flaggedRelations, otherFlag.flaggedRelations);
     }
 
     /**
@@ -293,7 +295,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     /**
      * @return a set of flagged {@link Relation}s
      */
-    public Set<FlaggedRelation> getFlaggedRelations()
+    public Set<FlaggedObject> getFlaggedRelations()
     {
         return this.flaggedRelations;
     }
@@ -411,7 +413,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     public int hashCode()
     {
         return Objects.hash(this.identifier, this.challengeName, this.instructions,
-                this.flaggedObjects);
+                this.flaggedObjects, this.flaggedRelations);
     }
 
     @Override
@@ -477,7 +479,21 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     private JsonObject boundsGeoJsonGeometry()
     {
-        final Iterator<FlaggedObject> iterator = flaggedObjects.iterator();
+        final Iterator<FlaggedObject> iterator;
+        if (!this.flaggedRelations.isEmpty() && !this.flaggedObjects.isEmpty())
+        {
+            iterator = Iterators.concat(this.flaggedRelations.iterator(),
+                    this.flaggedObjects.iterator());
+        }
+
+        else if (!this.flaggedRelations.isEmpty())
+        {
+            iterator = this.flaggedRelations.iterator();
+        }
+        else
+        {
+            iterator = this.flaggedObjects.iterator();
+        }
         Rectangle bounds;
 
         // Get the first bounds.

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -329,14 +329,13 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     }
 
     /**
-     * @return a list of {@link GeoJsonBuilder.LocationIterableProperties} representing all flagged
-     *         geometries
+     * @return a list of {@link GeometryWithProperties} representing all flagged geometries
      */
-    public List<GeometryWithProperties> getLocationIterableProperties()
+    public List<GeometryWithProperties> getGeometryWithProperties()
     {
         return this.flaggedObjects.stream()
-                .map(flaggedObject -> new GeoJsonBuilder.GeometryWithProperties(
-                        flaggedObject.getGeometry(), new HashMap<>(flaggedObject.getProperties())))
+                .map(flaggedObject -> new GeometryWithProperties(flaggedObject.getGeometry(),
+                        new HashMap<>(flaggedObject.getProperties())))
                 .collect(Collectors.toList());
     }
 
@@ -371,7 +370,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         }
 
         final JsonArray features = new JsonArray();
-        this.getLocationIterableProperties()
+        // Need to update with flaggedRelations as well
+        this.getGeometryWithProperties()
                 .forEach(shape -> features.add(new GeoJsonBuilder().create(shape)));
         task.setGeoJson(Optional.of(features));
 

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
@@ -21,9 +21,9 @@ public abstract class FlaggedObject implements Serializable, Located
     protected static final String COUNTRY_MISSING = "NA";
     protected static final String AREA_TAG = "Area";
     protected static final String EDGE_TAG = "Edge";
-    protected static final String OSM_IDENTIFIER_TAG = "osmid";
-    protected static final String ITEM_IDENTIFIER_TAG = "ItemId";
-    protected static final String ITEM_TYPE_TAG = "ItemType";
+    protected static final String OSM_IDENTIFIER_TAG = "osmIdentifier";
+    protected static final String ITEM_IDENTIFIER_TAG = "identifier";
+    protected static final String ITEM_TYPE_TAG = "itemType";
     protected static final String LINE_TAG = "Line";
     protected static final String NODE_TAG = "Node";
     protected static final String POINT_TAG = "Point";

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -70,7 +70,7 @@ public class FlaggedRelation extends FlaggedObject
     @Override
     public Rectangle bounds()
     {
-        return null;
+        return this.relation.bounds();
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -51,19 +51,13 @@ public class FlaggedRelation extends FlaggedObject
      * A GeoJSON representation of the flagged object.
      *
      * @param flagIdentifier
-     *            We always will want to know the id of the flag assocaited with this flag object.
+     *            We always will want to know the id of the flag associated with this flag object.
      * @return GeoJSON representation of the flagged object.
      */
     @Override
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
-
         final JsonObject feature = this.relation.asGeoJsonFeature();
-        final JsonObject properties = feature.getAsJsonObject("properties");
-
-        properties.addProperty("flag:id", flagIdentifier);
-        properties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
-
         return feature;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -58,6 +58,9 @@ public class FlaggedRelation extends FlaggedObject
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
         final JsonObject feature = this.relation.asGeoJsonFeature();
+        final JsonObject properties = feature.getAsJsonObject("properties");
+        properties.addProperty("flag:id", flagIdentifier);
+        properties.addProperty("flag:type", FlaggedPolyline.class.getSimpleName());
         return feature;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -1,0 +1,112 @@
+package org.openstreetmap.atlas.checks.flag;
+
+import java.util.Map;
+
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+
+import com.google.gson.JsonObject;
+
+/**
+ * A flag for a {@link Relation}
+ *
+ * @author sayas01
+ */
+public class FlaggedRelation extends FlaggedObject
+{
+    private final Relation relation;
+    private final Map<String, String> properties;
+
+    public FlaggedRelation(final Relation relation)
+    {
+        this.relation = relation;
+        this.properties = initProperties(relation);
+    }
+
+    /**
+     * As relations itself do not have a geometry, the geometry of FlaggedRelation is set to null.
+     *
+     * @return flagged geometry
+     */
+    @Override
+    public Iterable<Location> getGeometry()
+    {
+        return null;
+    }
+
+    /**
+     * @return flag key-value property map
+     */
+    @Override
+    public Map<String, String> getProperties()
+    {
+        return this.properties;
+    }
+
+    /**
+     * A GeoJSON representation of the flagged object.
+     *
+     * @param flagIdentifier
+     *            We always will want to know the id of the flag assocaited with this flag object.
+     * @return GeoJSON representation of the flagged object.
+     */
+    @Override
+    public JsonObject asGeoJsonFeature(final String flagIdentifier)
+    {
+
+        final JsonObject feature = this.relation.asGeoJsonFeature();
+        final JsonObject properties = feature.getAsJsonObject("properties");
+
+        properties.addProperty("flag:id", flagIdentifier);
+        properties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
+
+        return feature;
+    }
+
+    /**
+     * @return The bounds of the object.
+     */
+    @Override
+    public Rectangle bounds()
+    {
+        return null;
+    }
+
+    /**
+     * @return list of all members of the relation
+     */
+    public RelationMemberList members()
+    {
+        return this.relation.members();
+    }
+
+    /**
+     * Helper method to check FlaggedRelation is of multipolygon type
+     *
+     * @return true if the flagged relation is a multipolygon
+     */
+    public boolean isMultipolygonRelation()
+    {
+        return Validators.isOfType(this.relation, RelationTypeTag.class,
+                RelationTypeTag.MULTIPOLYGON);
+    }
+
+    /**
+     * Populate properties of relation
+     *
+     * @param relation
+     * @return map of relation tags with additional key-value properties
+     */
+    private Map<String, String> initProperties(final Relation relation)
+    {
+        final Map<String, String> tags = relation.getTags();
+        tags.put(ITEM_IDENTIFIER_TAG, relation.getIdentifier() + "");
+        tags.put(OSM_IDENTIFIER_TAG, relation.getOsmIdentifier() + "");
+        tags.put(ITEM_TYPE_TAG, "Relation");
+        return tags;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -60,7 +60,7 @@ public class FlaggedRelation extends FlaggedObject
         final JsonObject feature = this.relation.asGeoJsonFeature();
         final JsonObject properties = feature.getAsJsonObject("properties");
         properties.addProperty("flag:id", flagIdentifier);
-        properties.addProperty("flag:type", FlaggedPolyline.class.getSimpleName());
+        properties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
         return feature;
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
@@ -122,8 +122,6 @@ public class CheckFlagTest
         this.setup.getAtlasWithRelations().relations().forEach(flag::addObject);
         // Tests if both the relations are added to flag
         Assert.assertEquals(flag.getFlaggedRelations().size(), 2);
-        // Tests if entities other than relations are not flagged
-        Assert.assertTrue(flag.getFlaggedObjects().isEmpty());
     }
 
     @Test
@@ -134,7 +132,7 @@ public class CheckFlagTest
         // Tests if both the relations are added to flag
         Assert.assertEquals(flag.getFlaggedRelations().size(), 2);
         // Tests if entities other than relations are also flagged
-        Assert.assertEquals(flag.getFlaggedObjects().size(), 13);
+        Assert.assertEquals(flag.getFlaggedObjects().size(), 15);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
@@ -119,8 +119,7 @@ public class CheckFlagTest
     public void testFlaggedRelations()
     {
         final CheckFlag flag = new CheckFlag("a-identifier");
-        this.setup.getAtlasWithRelations().relations()
-                .forEach(relation -> flag.addObject(relation));
+        this.setup.getAtlasWithRelations().relations().forEach(flag::addObject);
         // Tests if both the relations are added to flag
         Assert.assertEquals(flag.getFlaggedRelations().size(), 2);
         // Tests if entities other than relations are not flagged
@@ -131,8 +130,7 @@ public class CheckFlagTest
     public void testAllFlaggedObjects()
     {
         final CheckFlag flag = new CheckFlag("a-identifier");
-        this.setup.getAtlasWithRelations().entities()
-                .forEach(atlasEntity -> flag.addObject(atlasEntity));
+        this.setup.getAtlasWithRelations().entities().forEach(flag::addObject);
         // Tests if both the relations are added to flag
         Assert.assertEquals(flag.getFlaggedRelations().size(), 2);
         // Tests if entities other than relations are also flagged
@@ -143,10 +141,11 @@ public class CheckFlagTest
     public void testMembersOfFlaggedRelations()
     {
         final CheckFlag flag = new CheckFlag("a-identifier");
-        this.setup.getAtlasWithRelations().entities()
-                .forEach(atlasEntity -> flag.addObject(atlasEntity));
+        this.setup.getAtlasWithRelations().entities().forEach(flag::addObject);
         // Checks if members of flagged relations are added
-        Assert.assertEquals(flag.getFlaggedRelations().iterator().next().members().size(), 3);
+        final FlaggedRelation flaggedRelation = (FlaggedRelation) flag.getFlaggedRelations()
+                .iterator().next();
+        Assert.assertEquals(flaggedRelation.members().size(), 3);
         // Tests if list of geometriesWithProperties are populated for the flaggedObjects
         Assert.assertEquals(flag.getGeometryWithProperties().size(), 13);
     }
@@ -155,8 +154,7 @@ public class CheckFlagTest
     public void testFlagToFeature()
     {
         final CheckFlag flag = new CheckFlag("a-identifier");
-        this.setup.getAtlasWithRelations().entities()
-                .forEach(atlasEntity -> flag.addObject(atlasEntity));
+        this.setup.getAtlasWithRelations().entities().forEach(flag::addObject);
         Assert.assertEquals(CheckFlagEvent.flagToFeature(flag, new HashMap<>()).get("properties")
                 .getAsJsonObject().get("feature_count").getAsLong(), 15);
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTestRule.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.flag;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
@@ -9,6 +10,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
 /**
  * {@link CheckFlagTest} data generator
@@ -47,9 +50,55 @@ public class CheckFlagTestRule extends CoreTestRule
                     @Loc(value = TEST_4), @Loc(value = TEST_1),
                     @Loc(value = TEST_6) }, tags = { "building=yes" }) })
     private Atlas atlas;
+    @TestAtlas(
+            // Nodes
+            nodes = {
+                    @Node(id = "1", coordinates = @Loc(value = TEST_1), tags = { "a-tag=a-value" }),
+                    @Node(id = "2", coordinates = @Loc(value = TEST_2), tags = {
+                            "another-tag=another-value" }),
+                    @Node(id = "3", coordinates = @Loc(value = TEST_3), tags = { "third-tag=" }),
+                    @Node(id = "4", coordinates = @Loc(value = TEST_4), tags = { "fourth-tag=" }),
+                    @Node(id = "5", coordinates = @Loc(value = TEST_5), tags = { "fifth-tag=" }),
+                    @Node(id = "6", coordinates = @Loc(value = TEST_6), tags = { "sixth-tag=" }), },
+            // Points
+            points = {
+                    @Point(coordinates = @Loc(value = TEST_4), tags = {
+                            "sample-tag=sample-value" }),
+                    @Point(coordinates = @Loc(value = TEST_5), tags = { "test-tag=sample-value" }),
+                    @Point(coordinates = @Loc(value = TEST_6)) },
+            // Lines
+            lines = { @Line(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_6),
+                    @Loc(value = TEST_1) }, tags = { "sample-tag=sample-value" }) },
+            // Edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary" }),
+                    @Edge(id = "23", coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary" }), },
+            // Areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_1),
+                    @Loc(value = TEST_6) }, tags = { "building=yes" }) },
+            // Relations
+            relations = {
+                    @Relation(id = "123", members = {
+                            @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                            @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                            @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                                    "restriction=no_u_turn" }),
+                    @Relation(id = "456", members = {
+                            @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                            @Member(id = "1", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA) }, tags = {
+                                    "restriction=no_right_turn" }) })
+    private Atlas atlasWithRelations;
 
     public Atlas getAtlas()
     {
         return this.atlas;
+    }
+
+    public Atlas getAtlasWithRelations()
+    {
+        return this.atlasWithRelations;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/InvalidMiniRoundaboutCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/InvalidMiniRoundaboutCheckTestRule.java
@@ -16,7 +16,7 @@ public class InvalidMiniRoundaboutCheckTestRule extends CoreTestRule
     public static final String THREE = "40.9609826, -5.6425880";
     public static final String FOUR = "40.9610646, -5.6425413";
     public static final String NODE_TAG = "Node";
-    public static final String ITEM_TYPE_TAG = "ItemType";
+    public static final String ITEM_TYPE_TAG = "itemType";
     public static final String EDGE_TAG = "Edge";
 
     // One two-way street ending in a roundabout -- should be a turning loop/circle despite extra


### PR DESCRIPTION
### Description:

This PR is a second version of [PR #4.](https://github.com/sayas01/atlas-checks/pull/4) This design makes use of the new Atlas-Checks method, `asGeoJsonFeature` to generate features for relations. As this method treats non-multipolygon relation geometry as a single bound of all geometries of its members, the geojson and flag output geometry for relations will be a single bound instead of array of geometries of all its members designed in [PR #4.](https://github.com/sayas01/atlas-checks/pull/4)

Update to this design will be to handle multipolygon and non multipolygon relations separately. Let me know your thoughts on the new design.

### Potential Impact:

These enhancements will have an effect on any checks that flag relations. As none of the existing checks flags relation, it will not affect any existing relation based check. To include the changes, relation based checks will need to be refactored to add relations instead of members.

### Unit Test Approach:

TODO

### Test Results:
NA

