### PR TITLE
Highway To Ferry Tag Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -413,5 +413,9 @@
       "difficulty": "NORMAL",
       "defaultPriority": "MEDIUM"
     }
+  },
+  "HighwayToFerryTagCheck": {
+    "enabled": true,
+    "highway.type.minimum": "path"
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -415,7 +415,6 @@
     }
   },
   "HighwayToFerryTagCheck": {
-    "enabled": true,
     "highway.type.minimum": "path"
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -415,6 +415,13 @@
     }
   },
   "HighwayToFerryTagCheck": {
-    "highway.type.minimum": "path"
+    "highway.type.minimum": "path",
+    "challenge": {
+      "description": "Ferry routes should have a Ferry Tag with a highway classification associated with them. Any ferry routes with a Highway Tag should be updated to a Ferry Tag and the Highway Tag should be dropped. ",
+      "blurb": "Improper tags for Ferry routes.",
+      "instruction": "Open your favorite editor and check the instruction for the task and then create or modify the Ferry Tag and delete the Highway Tag.",
+      "difficulty": "EASY",
+      "defaultPriority": "MEDIUM"
+    }
   }
 }

--- a/docs/checks/highwayToFerryTagCheck.md
+++ b/docs/checks/highwayToFerryTagCheck.md
@@ -25,9 +25,10 @@ The incoming Atlas object must meet the following criteria to be considered for 
 * Has to be a Master Edge and its OSM id should not have already been flagged
 * Has a *route=FERRY* Tag
 * Has a highway Tag  with priority greater than or equal to a minimum highway type. The default 
-minimum highway type is PATH which includes MOTORWAY,MOTORWAY_LINK,TRUNK,TRUNK_LINK,
-PRIMARY,PRIMARY_LINK,SECONDARY,SECONDARY_LINK,TERTIARY,TERTIARY_LINK,UNCLASSIFIED,RESIDENTIAL,SERVICE,
-TRACK,LIVING_STREET,PEDESTRIAN,BUS_GUIDEWAY,RACEWAY,ROAD,CYCLEWAY,FOOTWAY,BRIDLEWAY,STEPS,PATH. 
+minimum highway type is PATH which includes MOTORWAY, MOTORWAY_LINK, TRUNK,TRUNK_LINK, PRIMARY, 
+PRIMARY_LINK, SECONDARY, SECONDARY_LINK, TERTIARY, TERTIARY_LINK, UNCLASSIFIED, RESIDENTIAL, 
+SERVICE, TRACK, LIVING_STREET, PEDESTRIAN, BUS_GUIDEWAY, RACEWAY, ROAD, CYCLEWAY, FOOTWAY, 
+BRIDLEWAY, STEPS and PATH. 
 The minimum highway type is set as a configurable so that the default minimum type can be overridden.
 
 The object is then flagged with appropriate instructions based on the following conditions:

--- a/docs/checks/highwayToFerryTagCheck.md
+++ b/docs/checks/highwayToFerryTagCheck.md
@@ -1,0 +1,43 @@
+# HighwayToFerryTagCheck
+
+#### Description
+
+The purpose of this check is to flag all Edges with *route=FERRY* and *highway=PATH* (or higher). 
+According to [OSM Wiki](https://wiki.openstreetmap.org/wiki/Key:ferry), when *route=FERRY* exists for an object, 
+its ferry Tag can take values of highway classification and so, it is recommended to have a ferry Tag
+with the highway Tag value instead of a highway Tag for ferry routes.
+
+#### Live Examples
+
+1) The OSM Way [25957980](https://www.openstreetmap.org/way/25957980), ingested as an Edge, 
+has *route=FERRY*, *ferry=YES* and *highway=TERTIARY* Tags. The ferry Tag should have the value of 
+the highway classification instead of the additional highway Tag.
+
+2) The OSM Way [256442950](https://www.openstreetmap.org/way/256442950), ingested as an Edge, 
+has *route=FERRY* and *highway=TERTIARY* Tags. Since this is a ferry route, the Tag should be 
+*ferry=TERTIARY* and not *highway=TERTIARY.*
+
+#### Code Review
+
+In Atlas, OSM elements are represented as Points, Lines, Edges, Areas and Relations. In our case, we're
+looking at edges. 
+The incoming Atlas object must meet the following criteria to be considered for flagging:
+* Has to be a Master Edge and its OSM id should not have already been flagged
+* Has a *route=FERRY* Tag
+* Has a highway Tag  with priority greater than or equal to a minimum highway type. The default 
+minimum highway type is PATH which includes MOTORWAY,MOTORWAY_LINK,TRUNK,TRUNK_LINK,
+PRIMARY,PRIMARY_LINK,SECONDARY,SECONDARY_LINK,TERTIARY,TERTIARY_LINK,UNCLASSIFIED,RESIDENTIAL,SERVICE,
+TRACK,LIVING_STREET,PEDESTRIAN,BUS_GUIDEWAY,RACEWAY,ROAD,CYCLEWAY,FOOTWAY,BRIDLEWAY,STEPS,PATH. 
+The minimum highway type is set as a configurable so that the default minimum type can be overridden.
+
+The object is then flagged with appropriate instructions based on the following conditions:
+* If the object has a Ferry Tag and is not of the same classification as the Highway Tag
+* If the object has a Ferry Tag and is of the same classification as the Highway Tag
+* If the object has no Ferry Tag
+
+
+###### More Information
+For more information, see the source code in 
+[HighwayToFerryTagCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheck.java).
+
+

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheck.java
@@ -1,0 +1,92 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.FerryTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.RouteTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Based on the osm wiki, when route=ferry exists, there should be a ferry=* tag where the values of
+ * ferry are highway values. This check flags all edges that have both {@link HighwayTag} and
+ * {@link RouteTag} value equal to "FERRY".
+ *
+ * @author sayas01
+ */
+public class HighwayToFerryTagCheck extends BaseCheck
+{
+    private static final String MINIMUM_HIGHWAY_TYPE_DEFAULT = HighwayTag.PATH.toString();
+    private static final String FERRY_TAG_IF_PRESENT_INSTRUCTION = "This way {0,number,#} has a Ferry and a Highway tag for a ferry route. "
+            + "Please verify and update the Ferry tag with the Highway tag value and remove the highway tag";
+    private static final String FERRY_TAG_IF_ABSENT_INSTRUCTION = "This way {0,number,#} has a Highway tag for a ferry route instead of a Ferry tag. "
+            + "Please verify and add a Ferry tag with the Highway tag value and remove the highway tag";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(FERRY_TAG_IF_PRESENT_INSTRUCTION, FERRY_TAG_IF_ABSENT_INSTRUCTION);
+
+    private final HighwayTag minimumHighwayType;
+    /**
+     * Default constructor
+     *
+     * @param configuration {@link Configuration} required to construct any Check
+     */
+    public HighwayToFerryTagCheck(
+            final Configuration configuration)
+    {
+        super(configuration);
+        final String highwayType = (String) this.configurationValue(configuration,
+                "highway.type.minimum", MINIMUM_HIGHWAY_TYPE_DEFAULT);
+        this.minimumHighwayType = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
+    }
+
+    /**
+     * Checks to see whether the supplied object class type is valid for this particular check
+     *
+     * @param object The {@link AtlasObject} you are checking
+     * @return true if it is
+     */
+    @Override public boolean validCheckForObject(final AtlasObject object)
+    {
+        return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
+                && Validators.isOfType(object, RouteTag.class, RouteTag.FERRY)
+                && this.isMinimumHighwayType(object) && !this.isFlagged(object.getOsmIdentifier());
+    }
+
+    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // Mark OSM id as flagged
+        this.markAsFlagged(object.getOsmIdentifier());
+        return Validators.hasValuesFor(object, FerryTag.class)? Optional.of(this.createFlag(object,
+                this.getLocalizedInstruction(0, object.getOsmIdentifier()))) :
+                Optional.of(this.createFlag(object, this.getLocalizedInstruction(1, object.getOsmIdentifier())));
+    }
+
+    /**
+     * Verifies that the priority of the {@link HighwayTag} of the {@link AtlasObject} is greater
+     * than or equal to the minimum highway type.
+     *
+     * @param object
+     *            {@link AtlasObject} whose {@link HighwayTag} is verified for minimum highway value
+     * @return true if the highway tag of the object is greater or equal to the minimum highway type
+     */
+    private boolean isMinimumHighwayType(final AtlasObject object)
+    {
+        final Optional<HighwayTag> highwayTagOfObject = HighwayTag.highwayTag(object);
+
+        return highwayTagOfObject.isPresent()
+                && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+    }
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheck.java
@@ -35,7 +35,6 @@ public class HighwayToFerryTagCheck extends BaseCheck
             + "Please verify and update the Ferry tag with the Highway tag value and remove the highway tag.";
     private static final Predicate<Taggable> HAS_FERRY_TAG = object -> Validators
             .hasValuesFor(object, FerryTag.class);
-
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             FERRY_TAG_IF_DIFFERENT_FROM_HIGHWAY_INSTRUCTION,
             FERRY_TAG_IF_SAME_AS_HIGHWAY_INSTRUCTION, FERRY_TAG_IF_ABSENT_INSTRUCTION);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
@@ -20,13 +20,23 @@ public class HighwayToFerryTagCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void testAtlasWithFerryAndHighwayTag()
+    public void testAtlasWithSameFerryAndHighwayTags()
     {
-        this.verifier.actual(this.setup.getFerryHighwayAtlas(),
+        this.verifier.actual(this.setup.getSameFerryHighwayAtlas(),
                 new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertTrue(flag.getInstructions()
-                .contains("has a Ferry and a Highway tag for a ferry route")));
+        this.verifier.verify(flag -> Assert.assertTrue(flag.getInstructions().contains(
+                "has a Ferry and a Highway tag for a ferry route. Please verify and remove the highway tag.")));
+    }
+
+    @Test
+    public void testAtlasWithDifferentFerryAndHighwayTags()
+    {
+        this.verifier.actual(this.setup.getDifferentFerryHighwayAtlas(),
+                new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertTrue(flag.getInstructions().contains(
+                "has a Ferry and a Highway tag for a ferry route. Please verify and update the Ferry tag with the Highway tag value and remove the highway tag.")));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
@@ -1,0 +1,61 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * {@link HighwayToFerryTagCheckTest} Unit Test
+ *
+ * @author sayas01
+ */
+public class HighwayToFerryTagCheckTest
+{
+    @Rule
+    public HighwayToFerryTagCheckTestRule setup = new HighwayToFerryTagCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testAtlasWithFerryAndHighwayTag()
+    {
+        this.verifier.actual(this.setup.getFerryHighwayAtlas(),
+                new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag ->
+                Assert.assertTrue(
+                        flag.getInstructions().contains("has a Ferry and a Highway tag for a ferry route")));
+    }
+
+    @Test
+    public void testAtlasWithNoFerryTag()
+    {
+        this.verifier.actual(this.setup.getHighwayAtlas(),
+                new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
+        this.verifier.verify(flag ->
+                Assert.assertTrue(
+                        flag.getInstructions().contains("has a Highway tag for a ferry route instead of a Ferry tag")));
+    }
+
+    @Test
+    public void testMinimumHighwayConfiguration()
+    {
+        this.verifier.actual(this.setup.getMinimumHighwayAtlas(),
+                new HighwayToFerryTagCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"HighwayToFerryTagCheck\":{\"highway.type.minimum\":\"service\"}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+    }
+
+    @Test
+    public void testAtlasWithValidFerryHighwayTags()
+    {
+        this.verifier.actual(this.setup.getValidAtlas(),
+                new HighwayToFerryTagCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"HighwayToFerryTagCheck\":{\"highway.type.minimum\":\"path\"}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTest.java
@@ -25,9 +25,8 @@ public class HighwayToFerryTagCheckTest
         this.verifier.actual(this.setup.getFerryHighwayAtlas(),
                 new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag ->
-                Assert.assertTrue(
-                        flag.getInstructions().contains("has a Ferry and a Highway tag for a ferry route")));
+        this.verifier.verify(flag -> Assert.assertTrue(flag.getInstructions()
+                .contains("has a Ferry and a Highway tag for a ferry route")));
     }
 
     @Test
@@ -36,9 +35,8 @@ public class HighwayToFerryTagCheckTest
         this.verifier.actual(this.setup.getHighwayAtlas(),
                 new HighwayToFerryTagCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
-        this.verifier.verify(flag ->
-                Assert.assertTrue(
-                        flag.getInstructions().contains("has a Highway tag for a ferry route instead of a Ferry tag")));
+        this.verifier.verify(flag -> Assert.assertTrue(flag.getInstructions()
+                .contains("has a Highway tag for a ferry route instead of a Ferry tag")));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
@@ -35,13 +35,13 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
                     @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=path",
-                            "ferry=YES" }),
+                                    "ferry=YES" }),
                     @Edge(id = "3000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=primary",
-                            "ferry=YES" }),
+                                    "ferry=YES" }),
                     @Edge(id = "4000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
-                            "ferry=YES" }) })
+                                    "ferry=YES" }) })
 
     private Atlas ferryHighwayAtlas;
 
@@ -59,16 +59,15 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
                     @Edge(id = "2000101", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_2) }, tags = { "highway=motorway",
-                            "route=ferry" }),
+                                    "route=ferry" }),
                     @Edge(id = "3000101", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_2) }, tags = { "highway=path",
-                            "route=ferry" }),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=path", "route=ferry" }),
                     @Edge(id = "4000101", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_2) }, tags = { "highway=motorway_link",
-                            "route=ferry" }),
+                                    "route=ferry" }),
                     @Edge(id = "5000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk",
-                            "route=ferry" }) })
+                                    "route=ferry" }) })
 
     private Atlas highwayAtlas;
 
@@ -86,7 +85,7 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
                     @Edge(id = "1000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "route=ferry",
-                            "ferry=primary" }) })
+                                    "ferry=primary" }) })
 
     private Atlas validAtlas;
     @TestAtlas(
@@ -103,16 +102,16 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
                     @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
-                            "ferry=YES" }),
+                                    "ferry=YES" }),
                     @Edge(id = "3000105", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_5) }, tags = { "highway=motorway", "route=ferry",
-                            "ferry=YES" }),
+                                    "ferry=YES" }),
                     @Edge(id = "4000104", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_5) }, tags = { "highway=path", "route=ferry",
-                            "ferry=YES" }),
+                                    "ferry=YES" }),
                     @Edge(id = "5000103", coordinates = { @Loc(value = LOCATION_4),
                             @Loc(value = LOCATION_5) }, tags = { "highway=construction",
-                            "route=ferry", "ferry=YES" }) })
+                                    "route=ferry", "ferry=YES" }) })
 
     private Atlas minimumHighwayAtlas;
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
@@ -1,0 +1,138 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * {@link HighwayToFerryTagCheckTest} test data
+ *
+ * @author sayas01
+ */
+public class HighwayToFerryTagCheckTestRule extends CoreTestRule
+{
+    private static final String LOCATION_1 = "37.3314171,-122.0304871";
+    private static final String LOCATION_2 = "37.3314261,-122.0304871";
+    private static final String LOCATION_3 = "37.3314171,-122.0304758";
+    private static final String LOCATION_4 = "37.3264092,-122.0211657";
+    private static final String LOCATION_5 = "37.3353134,-122.0095644";
+    private static final String LOCATION_6 = "37.3314171,-122.0304419";
+
+    @TestAtlas(
+
+            nodes = { @Node(id = "1", coordinates = @Loc(value = LOCATION_1)),
+                    @Node(id = "2", coordinates = @Loc(value = LOCATION_2)),
+                    @Node(id = "3", coordinates = @Loc(value = LOCATION_3)),
+                    @Node(id = "4", coordinates = @Loc(value = LOCATION_4)),
+                    @Node(id = "5", coordinates = @Loc(value = LOCATION_5)),
+                    @Node(id = "6", coordinates = @Loc(value = LOCATION_6)) },
+
+            edges = {
+                    @Edge(id = "1000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=path",
+                            "ferry=YES" }),
+                    @Edge(id = "3000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=primary",
+                            "ferry=YES" }),
+                    @Edge(id = "4000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
+                            "ferry=YES" }) })
+
+    private Atlas ferryHighwayAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(id = "1", coordinates = @Loc(value = LOCATION_1)),
+                    @Node(id = "2", coordinates = @Loc(value = LOCATION_2)),
+                    @Node(id = "3", coordinates = @Loc(value = LOCATION_3)),
+                    @Node(id = "4", coordinates = @Loc(value = LOCATION_4)),
+                    @Node(id = "5", coordinates = @Loc(value = LOCATION_5)),
+                    @Node(id = "6", coordinates = @Loc(value = LOCATION_6)) },
+
+            edges = {
+                    @Edge(id = "1000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "2000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                            "route=ferry" }),
+                    @Edge(id = "3000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=path",
+                            "route=ferry" }),
+                    @Edge(id = "4000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=motorway_link",
+                            "route=ferry" }),
+                    @Edge(id = "5000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk",
+                            "route=ferry" }) })
+
+    private Atlas highwayAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(id = "1", coordinates = @Loc(value = LOCATION_1)),
+                    @Node(id = "2", coordinates = @Loc(value = LOCATION_2)),
+                    @Node(id = "3", coordinates = @Loc(value = LOCATION_3)),
+                    @Node(id = "4", coordinates = @Loc(value = LOCATION_4)),
+                    @Node(id = "5", coordinates = @Loc(value = LOCATION_5)),
+                    @Node(id = "6", coordinates = @Loc(value = LOCATION_6)) },
+
+            edges = {
+                    @Edge(id = "1000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "1000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "route=ferry",
+                            "ferry=primary" }) })
+
+    private Atlas validAtlas;
+    @TestAtlas(
+
+            nodes = { @Node(id = "1", coordinates = @Loc(value = LOCATION_1)),
+                    @Node(id = "2", coordinates = @Loc(value = LOCATION_2)),
+                    @Node(id = "3", coordinates = @Loc(value = LOCATION_3)),
+                    @Node(id = "4", coordinates = @Loc(value = LOCATION_4)),
+                    @Node(id = "5", coordinates = @Loc(value = LOCATION_5)),
+                    @Node(id = "6", coordinates = @Loc(value = LOCATION_6)) },
+
+            edges = {
+                    @Edge(id = "1000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
+                            "ferry=YES" }),
+                    @Edge(id = "3000105", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway", "route=ferry",
+                            "ferry=YES" }),
+                    @Edge(id = "4000104", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=path", "route=ferry",
+                            "ferry=YES" }),
+                    @Edge(id = "5000103", coordinates = { @Loc(value = LOCATION_4),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=construction",
+                            "route=ferry", "ferry=YES" }) })
+
+    private Atlas minimumHighwayAtlas;
+
+    public Atlas getFerryHighwayAtlas()
+    {
+        return this.ferryHighwayAtlas;
+    }
+
+    public Atlas getHighwayAtlas()
+    {
+        return this.highwayAtlas;
+    }
+
+    public Atlas getValidAtlas()
+    {
+        return this.validAtlas;
+    }
+
+    public Atlas getMinimumHighwayAtlas()
+    {
+        return this.minimumHighwayAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/HighwayToFerryTagCheckTestRule.java
@@ -35,6 +35,30 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
                     @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=path",
+                                    "ferry=trunk" }),
+                    @Edge(id = "3000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=primary", "route=primary",
+                                    "ferry=primary" }),
+                    @Edge(id = "4000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
+                                    "ferry=trunk" }) })
+
+    private Atlas sameFerryHighwayTagsAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(id = "1", coordinates = @Loc(value = LOCATION_1)),
+                    @Node(id = "2", coordinates = @Loc(value = LOCATION_2)),
+                    @Node(id = "3", coordinates = @Loc(value = LOCATION_3)),
+                    @Node(id = "4", coordinates = @Loc(value = LOCATION_4)),
+                    @Node(id = "5", coordinates = @Loc(value = LOCATION_5)),
+                    @Node(id = "6", coordinates = @Loc(value = LOCATION_6)) },
+
+            edges = {
+                    @Edge(id = "1000101", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_2) }, tags = { "highway=trunk" }),
+                    @Edge(id = "2000102", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=path",
                                     "ferry=YES" }),
                     @Edge(id = "3000102", coordinates = { @Loc(value = LOCATION_2),
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=primary",
@@ -43,7 +67,7 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_3) }, tags = { "highway=trunk", "route=ferry",
                                     "ferry=YES" }) })
 
-    private Atlas ferryHighwayAtlas;
+    private Atlas differentFerryHighwayTagsAtlas;
 
     @TestAtlas(
 
@@ -115,9 +139,14 @@ public class HighwayToFerryTagCheckTestRule extends CoreTestRule
 
     private Atlas minimumHighwayAtlas;
 
-    public Atlas getFerryHighwayAtlas()
+    public Atlas getSameFerryHighwayAtlas()
     {
-        return this.ferryHighwayAtlas;
+        return this.sameFerryHighwayTagsAtlas;
+    }
+
+    public Atlas getDifferentFerryHighwayAtlas()
+    {
+        return this.differentFerryHighwayTagsAtlas;
     }
 
     public Atlas getHighwayAtlas()


### PR DESCRIPTION
### Description:

This PR is to add a new Integrity Check - HighwayToFerryTagCheck. The purpose of this check is to flag all Edges with *route=FERRY* and *highway=PATH* (or higher). According to [OSM wiki](https://wiki.openstreetmap.org/wiki/Key:ferry), when *route=FERRY* exists, the ferry Tag can take values of highway classification and so, it is recommended to have a ferry Tag with the highway Tag value instead of the highway Tag itself. 

### Potential Impact:

Flags Edges that are Ferry routes if there is no corresponding Ferry tag with a highway classification or if it has both Ferry and Highway tags.

### Unit Test Approach:

Various unit tests have been added to test the functionality of the check.

### Test Results:

All tests passing successfully.

