### PR TITLE
SinkIslandCheck Enhancements to Exclude Airport Roads

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/atlas/predicates/TagPredicates.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/atlas/predicates/TagPredicates.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.atlas.predicates;
 import java.util.function.Predicate;
 
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.tags.AccessTag;
 import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.BridgeTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
@@ -106,4 +107,17 @@ public interface TagPredicates
      */
     Predicate<AtlasObject> IS_CROSSING_HIGHWAY = object -> Validators.isOfType(object,
             HighwayTag.class, HighwayTag.CROSSING);
+
+    /**
+     * Tests if the {@link AtlasObject} has car navigable highway type and access tag not in Private
+     * enum set
+     */
+    Predicate<AtlasObject> IS_CAR_NAVIGABLE_NON_PRIVATE_HIGHWAY = object -> HighwayTag
+            .isCarNavigableHighway(object) && !AccessTag.isPrivate(object);
+
+    /**
+     * Tests if the {@link AtlasObject} has car navigable highway type and access=!no tag
+     */
+    Predicate<AtlasObject> IS_CAR_NAVIGABLE_HIGHWAY = object -> HighwayTag
+            .isCarNavigableHighway(object) && !AccessTag.isNo(object);
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/atlas/predicates/TagPredicates.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/atlas/predicates/TagPredicates.java
@@ -3,7 +3,6 @@ package org.openstreetmap.atlas.checks.atlas.predicates;
 import java.util.function.Predicate;
 
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
-import org.openstreetmap.atlas.tags.AccessTag;
 import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.BridgeTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
@@ -107,17 +106,4 @@ public interface TagPredicates
      */
     Predicate<AtlasObject> IS_CROSSING_HIGHWAY = object -> Validators.isOfType(object,
             HighwayTag.class, HighwayTag.CROSSING);
-
-    /**
-     * Tests if the {@link AtlasObject} has car navigable highway type and access tag not in Private
-     * enum set
-     */
-    Predicate<AtlasObject> IS_CAR_NAVIGABLE_NON_PRIVATE_HIGHWAY = object -> HighwayTag
-            .isCarNavigableHighway(object) && !AccessTag.isPrivate(object);
-
-    /**
-     * Tests if the {@link AtlasObject} has car navigable highway type and access=!no tag
-     */
-    Predicate<AtlasObject> IS_CAR_NAVIGABLE_HIGHWAY = object -> HighwayTag
-            .isCarNavigableHighway(object) && !AccessTag.isNo(object);
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -317,15 +317,15 @@ public class SinkIslandCheck extends BaseCheck<Long>
 
     /**
      * Checks if the edge is publicly accessible. An edge is considered accessible to the public if
-     * the {@link AccessTag} is not present or if present, is not one of the values in
-     * the PRIVATE_ACCESS set in {@link AccessTag}.
+     * the {@link AccessTag} is not present or if present, is not one of the values in the
+     * PRIVATE_ACCESS set in {@link AccessTag}.
      * 
      * @param edge
-     * @return
+     *            any Edge
+     * @return true if the edge is accessible
      */
     private boolean isAccessible(final Edge edge)
     {
-        return !Validators.hasValuesFor(edge, AccessTag.class)
-                || !AccessTag.isPrivate(edge);
+        return !Validators.hasValuesFor(edge, AccessTag.class) || !AccessTag.isPrivate(edge);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -51,8 +51,6 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private static final String DEFAULT_MINIMUM_HIGHWAY_TYPE = "SERVICE";
     private static final Predicate<AtlasObject> SERVICE_ROAD = object -> Validators.isOfType(object,
             HighwayTag.class, HighwayTag.SERVICE);
-    private static final Predicate<AtlasObject> PUBLIC_ACCESS_HIGHWAYS = object -> HighwayTag
-            .isCarNavigableHighway(object) && !AccessTag.isPrivate(object);
     private static final Predicate<AtlasObject> NAVIGABLE_HIGHWAYS = object -> Validators
             .isOfType(object, MotorVehicleTag.class, MotorVehicleTag.YES)
             || Validators.isOfType(object, MotorcarTag.class, MotorcarTag.YES)
@@ -198,10 +196,12 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private boolean validEdge(final AtlasObject object)
     {
         return object instanceof Edge
-                // Only allow car navigable highways (access not ion private enum set and
+                // Only allow car navigable highways (access = yes and
                 // motorvehicle/motorcar/vehicle = yes)
                 // and ignore ferries
-                && PUBLIC_ACCESS_HIGHWAYS.test(object) && NAVIGABLE_HIGHWAYS.test(object)
+                && HighwayTag
+                .isCarNavigableHighway(object) && Validators.isOfType(object, AccessTag.class,
+                AccessTag.YES) && NAVIGABLE_HIGHWAYS.test(object)
                 && !RouteTag.isFerry(object)
                 // Ignore any highways tagged as areas
                 && !TagPredicates.IS_AREA.test(object);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -25,6 +25,7 @@ import org.openstreetmap.atlas.tags.MotorcarTag;
 import org.openstreetmap.atlas.tags.RouteTag;
 import org.openstreetmap.atlas.tags.ServiceTag;
 import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
+import org.openstreetmap.atlas.tags.VehicleTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -315,6 +316,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
     {
         return TagPredicates.IS_CAR_NAVIGABLE_NON_PRIVATE_HIGHWAY.test(edge)
                 && !(Validators.isOfType(edge, MotorVehicleTag.class, MotorVehicleTag.NO)
-                        || Validators.isOfType(edge, MotorcarTag.class, MotorcarTag.NO));
+                        || Validators.isOfType(edge, MotorcarTag.class, MotorcarTag.NO)
+        || Validators.isOfType(edge, VehicleTag.class, VehicleTag.NO));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -15,7 +15,6 @@ import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.tags.AerowayTag;
 import org.openstreetmap.atlas.tags.AmenityTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
@@ -208,8 +207,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private boolean endOrStartNodeHasAmenityTypeToExclude(final AtlasObject object)
     {
         final Edge edge = (Edge) object;
-        final Node endNode = edge.end();
-        return Validators.isOfType(endNode, AmenityTag.class, AMENITY_VALUES_TO_EXCLUDE)
+        return Validators.isOfType(edge.end(), AmenityTag.class, AMENITY_VALUES_TO_EXCLUDE)
                 || Validators.isOfType(edge.start(), AmenityTag.class, AmenityTag.PARKING_ENTRANCE);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -16,7 +16,6 @@ import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
-import org.openstreetmap.atlas.tags.AccessTag;
 import org.openstreetmap.atlas.tags.AerowayTag;
 import org.openstreetmap.atlas.tags.AmenityTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
@@ -314,7 +313,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
      */
     private boolean isCarNavigableHighway(final Edge edge)
     {
-        return HighwayTag.isCarNavigableHighway(edge) && !AccessTag.isPrivate(edge)
+        return TagPredicates.IS_CAR_NAVIGABLE_NON_PRIVATE_HIGHWAY.test(edge)
                 && !(Validators.isOfType(edge, MotorVehicleTag.class, MotorVehicleTag.NO)
                         || Validators.isOfType(edge, MotorcarTag.class, MotorcarTag.NO));
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -198,8 +198,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // motorvehicle/motorcar/vehicle = yes)
                 // and ignore ferries
                 && HighwayTag.isCarNavigableHighway(object)
-                && Validators.isOfType(object, AccessTag.class, AccessTag.YES)
-                && NAVIGABLE_HIGHWAYS.test(object) && !RouteTag.isFerry(object)
+                && this.isAccessible((Edge) object) && this.isNavigable((Edge)object)
+                && !RouteTag.isFerry(object)
                 // Ignore any highways tagged as areas
                 && !TagPredicates.IS_AREA.test(object);
     }
@@ -296,5 +296,32 @@ public class SinkIslandCheck extends BaseCheck<Long>
                                         || Validators.hasValuesFor(area, AerowayTag.class))
                         .spliterator(), false)
                 .anyMatch(area -> area.asPolygon().overlaps(edge.asPolyLine()));
+    }
+
+    /**
+     * Checks if the edge is car navigable in terms of {@link MotorVehicleTag}, {@link MotorcarTag} and {@link VehicleTag}. Edge is navigable if
+     * 1) MotorVehicleTag, MotorcarTag and VehicleTag is absent or
+     * 2) If present, its value equals YES.
+     *
+     * @param edge any Edge
+     * @return true if the edge is navigable
+     */
+    private boolean isNavigable(final Edge edge)
+    {
+        return !Validators.hasValuesFor(edge, MotorVehicleTag.class) &&
+                !Validators.hasValuesFor(edge, MotorcarTag.class) && !Validators
+                .hasValuesFor(edge, VehicleTag.class) || NAVIGABLE_HIGHWAYS.test(edge);
+    }
+
+    /**
+     * Checks if the edge is publicly accessible. An edge is considered accessible to the public if the {@link AccessTag}
+     * is not explicitly given or if present, its value equals YES.
+     * @param edge
+     * @return
+     */
+    private boolean isAccessible(final Edge edge)
+    {
+        return !Validators.hasValuesFor(edge, AccessTag.class) || Validators
+                .isOfType(edge, AccessTag.class, AccessTag.YES);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -85,8 +85,9 @@ public class SinkIslandCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return this.validEdge(object) && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
-                .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType)
+        return this.validEdge(object) && !this.isFlagged(object.getIdentifier())
+                && ((Edge) object).highwayTag()
+                        .isMoreImportantThanOrEqualTo(this.minimumHighwayType)
                 && !(SERVICE_ROAD.test(object)
                         && (this.isWithinAreasWithExcludedAmenityTags((Edge) object)
                                 || this.intersectsAirportOrBuilding((Edge) object)));
@@ -197,9 +198,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // Only allow car navigable highways (access = yes and
                 // motorvehicle/motorcar/vehicle = yes)
                 // and ignore ferries
-                && HighwayTag.isCarNavigableHighway(object)
-                && this.isAccessible((Edge) object) && this.isNavigable((Edge)object)
-                && !RouteTag.isFerry(object)
+                && HighwayTag.isCarNavigableHighway(object) && this.isAccessible((Edge) object)
+                && this.isNavigable((Edge) object) && !RouteTag.isFerry(object)
                 // Ignore any highways tagged as areas
                 && !TagPredicates.IS_AREA.test(object);
     }
@@ -299,29 +299,32 @@ public class SinkIslandCheck extends BaseCheck<Long>
     }
 
     /**
-     * Checks if the edge is car navigable in terms of {@link MotorVehicleTag}, {@link MotorcarTag} and {@link VehicleTag}. Edge is navigable if
-     * 1) MotorVehicleTag, MotorcarTag and VehicleTag is absent or
-     * 2) If present, its value equals YES.
+     * Checks if the edge is car navigable in terms of {@link MotorVehicleTag}, {@link MotorcarTag}
+     * and {@link VehicleTag}. Edge is navigable if 1) MotorVehicleTag, MotorcarTag and VehicleTag
+     * is absent or 2) If present, its value equals YES.
      *
-     * @param edge any Edge
+     * @param edge
+     *            any Edge
      * @return true if the edge is navigable
      */
     private boolean isNavigable(final Edge edge)
     {
-        return !Validators.hasValuesFor(edge, MotorVehicleTag.class) &&
-                !Validators.hasValuesFor(edge, MotorcarTag.class) && !Validators
-                .hasValuesFor(edge, VehicleTag.class) || NAVIGABLE_HIGHWAYS.test(edge);
+        return !Validators.hasValuesFor(edge, MotorVehicleTag.class)
+                && !Validators.hasValuesFor(edge, MotorcarTag.class)
+                && !Validators.hasValuesFor(edge, VehicleTag.class)
+                || NAVIGABLE_HIGHWAYS.test(edge);
     }
 
     /**
-     * Checks if the edge is publicly accessible. An edge is considered accessible to the public if the {@link AccessTag}
-     * is not explicitly given or if present, its value equals YES.
+     * Checks if the edge is publicly accessible. An edge is considered accessible to the public if
+     * the {@link AccessTag} is not explicitly given or if present, its value equals YES.
+     * 
      * @param edge
      * @return
      */
     private boolean isAccessible(final Edge edge)
     {
-        return !Validators.hasValuesFor(edge, AccessTag.class) || Validators
-                .isOfType(edge, AccessTag.class, AccessTag.YES);
+        return !Validators.hasValuesFor(edge, AccessTag.class)
+                || Validators.isOfType(edge, AccessTag.class, AccessTag.YES);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -196,7 +196,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
     {
         return object instanceof Edge
                 // Only allow car navigable highways (access = yes and
-                // motorvehicle/motorcar/vehicle = yes)
+                // motor_vehicle/motorcar/vehicle = yes)
                 // and ignore ferries
                 && HighwayTag.isCarNavigableHighway(object) && this.isAccessible((Edge) object)
                 && this.isNavigable((Edge) object) && !RouteTag.isFerry(object)
@@ -317,7 +317,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
 
     /**
      * Checks if the edge is publicly accessible. An edge is considered accessible to the public if
-     * the {@link AccessTag} is not explicitly given or if present, its value equals YES.
+     * the {@link AccessTag} is not present or if present, is not one of the values in
+     * the PRIVATE_ACCESS set in {@link AccessTag}.
      * 
      * @param edge
      * @return
@@ -325,6 +326,6 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private boolean isAccessible(final Edge edge)
     {
         return !Validators.hasValuesFor(edge, AccessTag.class)
-                || Validators.isOfType(edge, AccessTag.class, AccessTag.YES);
+                || !AccessTag.isPrivate(edge);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -7,6 +7,8 @@ import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 
 /**
+ * Unit tests for {@link SinkIslandCheck}
+ *
  * @author matthieun
  * @author gpogulsky
  * @author nachtm
@@ -83,7 +85,7 @@ public class SinkIslandCheckTest
         this.verifier.actual(this.setup.getInvalidEdges(),
                 new SinkIslandCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -109,5 +111,37 @@ public class SinkIslandCheckTest
         this.verifier.actual(this.setup.getEdgeWithinAreaWithAmenityTag(), new SinkIslandCheck(
                 ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testParkingGarageEntranceOrExit()
+    {
+        this.verifier.actual(this.setup.getParkingGarageEntranceOrExit(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testEdgesEndingInBuilding()
+    {
+        this.verifier.actual(this.setup.getEdgesEndingInBuilding(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testEdgesWithinAirport()
+    {
+        this.verifier.actual(this.setup.getEdgesWithinAirport(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testNonCarNavigableEdges()
+    {
+        this.verifier.actual(this.setup.getNonCarNavigableEdges(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyExpectedSize(1);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -31,6 +31,15 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     private static final String TEST_12 = "56.3092499, 9.1216749";
     private static final String TEST_13 = "56.3096026, 9.1211942";
     private static final String TEST_14 = "56.3098639, 9.1217029";
+    private static final String TEST_15 = "4.8711235, 114.9226319";
+    private static final String TEST_16 = "4.8716031, 114.9231528";
+    private static final String TEST_17 = "4.8718274, 114.9233965";
+    private static final String TEST_18 = "4.8714768, 114.9236523";
+    private static final String TEST_19 = "4.8716384, 114.9224705";
+    private static final String TEST_20 = "4.8719516, 114.9222574";
+    private static final String TEST_21 = "4.8721288, 114.9220754";
+    private static final String TEST_22 = "4.8723897, 114.9224152";
+    private static final String TEST_23 = "4.8721288, 114.9224435";
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_3)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_6)),
@@ -116,7 +125,7 @@ public class SinkIslandCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = TEST_2)),
             @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
-                            "highway=service", "aeroway=taxiway" }),
+                            "highway=service" }),
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=service", "route=ferry" }),
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
@@ -148,6 +157,46 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                                     @Loc(value = TEST_14) }, tags = { "highway=service",
                                             "service=parking_aisle" }) })
     private Atlas edgeWithinAreaWithAmenityTag;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_15)),
+            @Node(coordinates = @Loc(value = TEST_16)), @Node(coordinates = @Loc(value = TEST_17)),
+            @Node(coordinates = @Loc(value = TEST_18)) }, edges = {
+                    @Edge(id = "1", coordinates = { @Loc(value = TEST_15), @Loc(value = TEST_16),
+                            @Loc(value = TEST_17) }, tags = { "highway=service",
+                                    "access=private" }),
+                    @Edge(id = "2", coordinates = { @Loc(value = TEST_16),
+                            @Loc(value = TEST_18) }, tags = { "highway=service" }) })
+    private Atlas nonCarNavigableEdgesAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_19)),
+            @Node(coordinates = @Loc(value = TEST_20)), @Node(coordinates = @Loc(value = TEST_21)),
+            @Node(coordinates = @Loc(value = TEST_22)),
+            @Node(coordinates = @Loc(value = TEST_23)) }, areas = { @Area(coordinates = {
+                    @Loc(value = TEST_20), @Loc(value = TEST_21), @Loc(value = TEST_22),
+                    @Loc(value = TEST_23) }, tags = { "amenity=fuel" }) }, edges = {
+                            @Edge(id = "1", coordinates = { @Loc(value = TEST_19),
+                                    @Loc(value = TEST_20) }, tags = { "highway=service" }) })
+    private Atlas edgesEndingInBuildingAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_19)),
+            @Node(coordinates = @Loc(value = TEST_20), tags = { "amenity=parking_entrance" }),
+            @Node(coordinates = @Loc(value = TEST_21)), @Node(coordinates = @Loc(value = TEST_22)),
+            @Node(coordinates = @Loc(value = TEST_23)) }, areas = { @Area(coordinates = {
+                    @Loc(value = TEST_20), @Loc(value = TEST_21), @Loc(value = TEST_22),
+                    @Loc(value = TEST_23) }) }, edges = {
+                            @Edge(id = "1", coordinates = { @Loc(value = TEST_20),
+                                    @Loc(value = TEST_19) }, tags = { "highway=service" }) })
+    private Atlas parkingGarageEntranceOrExitAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_9)),
+            @Node(coordinates = @Loc(value = TEST_10)), @Node(coordinates = @Loc(value = TEST_11)),
+            @Node(coordinates = @Loc(value = TEST_12)), @Node(coordinates = @Loc(value = TEST_13)),
+            @Node(coordinates = @Loc(value = TEST_14)) }, areas = { @Area(coordinates = {
+                    @Loc(value = TEST_9), @Loc(value = TEST_10), @Loc(value = TEST_11),
+                    @Loc(value = TEST_12) }, tags = { "aeroway=aerodrome" }) }, edges = {
+                            @Edge(id = "1", coordinates = { @Loc(value = TEST_13),
+                                    @Loc(value = TEST_14) }, tags = { "highway=service" }) })
+    private Atlas edgesWithinAirportAtlas;
 
     public Atlas getSingleEdgeAtlas()
     {
@@ -197,5 +246,25 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getEdgeWithinAreaWithAmenityTag()
     {
         return this.edgeWithinAreaWithAmenityTag;
+    }
+
+    public Atlas getParkingGarageEntranceOrExit()
+    {
+        return this.parkingGarageEntranceOrExitAtlas;
+    }
+
+    public Atlas getEdgesEndingInBuilding()
+    {
+        return this.edgesEndingInBuildingAtlas;
+    }
+
+    public Atlas getEdgesWithinAirport()
+    {
+        return this.edgesWithinAirportAtlas;
+    }
+
+    public Atlas getNonCarNavigableEdges()
+    {
+        return this.nonCarNavigableEdgesAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -49,11 +49,14 @@ public class SinkIslandCheckTestRule extends CoreTestRule
 
             edges = {
                     @Edge(id = "160978519000001", coordinates = { @Loc(value = TEST_3),
-                            @Loc(value = TEST_2) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary", "oneway=yes",
+                                    "access=yes", "motor_vehicle=yes" }),
                     @Edge(id = "260978519000001", coordinates = { @Loc(value = TEST_2),
-                            @Loc(value = TEST_6) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary", "oneway=yes",
+                                    "access=yes", "motor_vehicle=yes" }),
                     @Edge(id = "360978519000001", coordinates = { @Loc(value = TEST_6),
-                            @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes",
+                                    "access=yes", "motor_vehicle=yes" }),
                     @Edge(id = "460978519000001", coordinates = { @Loc(value = TEST_7),
                             @Loc(value = TEST_4) }, tags = { "highway=primary", "oneway=yes" }),
                     @Edge(id = "560978519000001", coordinates = { @Loc(value = TEST_4),
@@ -74,7 +77,8 @@ public class SinkIslandCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = TEST_7)) },
 
             edges = { @Edge(id = "360978519000001", coordinates = { @Loc(value = TEST_6),
-                    @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes" }) })
+                    @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes", "access=yes",
+                            "vehicle=yes" }) })
     private Atlas singleEdgeAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_6)),
@@ -107,25 +111,25 @@ public class SinkIslandCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = TEST_2)),
             @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
-                            "highway=primary" }),
+                            "highway=primary", "access=yes", "motor_vehicle=yes" }),
                     @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
-                            "highway=track" }) })
+                            "highway=track", "access=yes", "vehicle=yes" }) })
     private Atlas trackAndHighwaySinkIsland;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)),
             @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
-                            "highway=service" }),
+                            "access=yes", "motor_vehicle=yes", "highway=service" }),
                     @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
-                            "highway=service" }) })
+                            "highway=service", "access=yes", "motor_vehicle=yes" }) })
     private Atlas serviceSinkIsland;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)),
             @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
-                            "highway=service" }),
+                            "highway=service", "access=yes", "motor_vehicle=yes" }),
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=service", "route=ferry" }),
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
@@ -133,9 +137,9 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                     @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
                             "highway=service", "area=yes" }),
                     @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
-                            "highway=service" }),
+                            "highway=service", "access=yes", "motor_vehicle=yes" }),
                     @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_1) }, tags = {
-                            "highway=service" }), })
+                            "highway=service", "access=yes", "motor_vehicle=yes" }), })
     private Atlas invalidEdges;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
@@ -165,7 +169,8 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                             @Loc(value = TEST_17) }, tags = { "highway=service",
                                     "access=private" }),
                     @Edge(id = "2", coordinates = { @Loc(value = TEST_16),
-                            @Loc(value = TEST_18) }, tags = { "highway=service" }) })
+                            @Loc(value = TEST_18) }, tags = { "highway=service", "access=yes",
+                                    "motor_vehicle=yes" }) })
     private Atlas nonCarNavigableEdgesAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_19)),


### PR DESCRIPTION
### Description:

This PR adds the following enhancements to SinkIslandCheck:
1) Exclude all service roads that are within any airport polygons. Current version has a validation that excludes edges that have aeroway tags with values runway or taxiway. Since ways with aeroway tags are not ingested as edges, this validation has been removed and a method that checks if the road(service highways) is within airport polygon has been added.
2) Previously only the end node of the edge was checked for _amenity=parking_entrance_ which resulted in some false positives. Additional validation to check for _amenity=parking_entrance_ tag at the start node of the edge has been added which should fix these cases.
3) Service roads that ends in buildings have been excluded from the check.
4) Previously, navigability of the edge was checked only in terms of highway tags. Additional validation in terms of _Access_ tag and _Motorvehicle_ and _Motorcar_ tags have been added to determine the car navigability of the edge.

### Potential Impact:

From the analysis, it was seen that there is both addition and subtraction of flags with these enhancements. Subtractions have been verified to be the cases that should be removed by these enhancements like services roads within airports. Additions have been verified to be mainly due to the updated car navigability condition. Most of the additions are for edges that are not marked _access=no_ but are connected to _access=no_ edges, which are valid sink islands.

### Unit Test Approach:

Unit tests have been added for the new updates. Additional validation has been done by testing the updates on a sample of countries and verifying it with the previous version.

### Test Results:

All tests passing and the additions and subtractions have been verified to be valid.
