### PR TITLE
Add PedestrianAreaOverlappingEdgeCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -449,5 +449,7 @@
       "difficulty": "EASY",
       "defaultPriority": "MEDIUM"
     }
+  },
+  "PedestrianAreaOverlappingEdgeCheck": {
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -451,5 +451,12 @@
     }
   },
   "PedestrianAreaOverlappingEdgeCheck": {
+    "challenge": {
+      "description": "Tasks contain pedestrian areas overlapping car navigable ways that are not properly snapped to those ways.",
+      "blurb": "Pedestrian areas overlapping car navigable ways.",
+      "instruction": "Open your favorite editor and check the instruction for the task and then properly snap all points of intersection of the pedestrian area to the overlapping car navigable ways.",
+      "difficulty": "MEDIUM",
+      "defaultPriority": "MEDIUM"
+    }
   }
 }

--- a/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
+++ b/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
@@ -9,7 +9,7 @@ highway=steps, highway=footway, and highway=pedestrian tag, which
 are too narrow to allow vehicle access.  This check only applies to pedestrian areas 
 where all points of intersection with roads are not snapped.  To be considered overlapping,
 pedestrian areas and roads must be at the same elevation, meaning, both the area and edge should have
-the same *LayerTag* and same *LocationTag*, if any. If these conditions are true, 
+the same *LayerTag* and same *LevelTag*, if any. If these conditions are true, 
 this check will flag pedestrian areas overlapping with unsnapped roads along with the unsnapped roads.
 
 #### Live Examples

--- a/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
+++ b/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
@@ -2,9 +2,9 @@
 
 #### Description
 
-The purpose of this check is to identify pedestrian areas overlapping with roads that are 
-not snapped to roads.  Pedestrian areas are defined as *Ways* with highway=PEDESTRIAN and
-area=YES tags.  Overlapping roads are *Edges* with any highway=** except highway=path, 
+The purpose of this check is to flag pedestrian areas that are not properly snapped to its 
+intersecting/overlapping edges. Pedestrian areas are defined as *Ways* with highway=PEDESTRIAN and
+area=YES tags. Overlapping roads are *Edges* with any highway=** except highway=path, 
 highway=steps, highway=footway, and highway=pedestrian tag, which 
 are too narrow to allow vehicle access.  This check only applies to pedestrian areas 
 where all points of intersection with roads are not snapped.  To be considered overlapping,
@@ -20,7 +20,7 @@ this check will flag pedestrian areas overlapping with unsnapped roads along wit
 #### Code Review
 
 The check ensures that the Atlas object being evaluated is an [Area](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java).
-The roads that intersects the area is then verified to be properly snapped to the area. If not, both the area, intersecting edge and any connected edges within the area are marked as 
+The roads that intersects the area is then verified to be properly snapped to the area. If not, the area, intersecting edge and any connected edges within the area are marked as 
 flagged.
 
 To learn more about the code, please look at the comments in the source code for the check.

--- a/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
+++ b/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
@@ -1,0 +1,27 @@
+# PedestrianAreaOverlappingEdgeCheck
+
+#### Description
+
+The purpose of this check is to identify pedestrian areas overlapping with roads that are 
+not snapped to roads.  Pedestrian areas are defined as *Ways* with highway=PEDESTRIAN and
+area=YES tags.  Overlapping roads are *Edges* with any highway=** except highway=path, 
+highway=steps, highway=footway, and highway=pedestrian tag, which 
+are too narrow to allow vehicle access.  This check only applies to pedestrian areas 
+where all points of intersection with roads are not snapped.  To be considered overlapping,
+pedestrian areas and roads must be at the same elevation, meaning, both the area and edge should have
+the same *LayerTag* and same *LocationTag*, if any. If these conditions are true, 
+this check will flag pedestrian areas overlapping with unsnapped roads along with the unsnapped roads.
+
+#### Live Examples
+
+1. Line [id:223986287](https://www.openstreetmap.org/way/223986287) is is not snapped to the road with which it overlaps.
+2. Line [id:575511688](https://www.openstreetmap.org/way/575511688) is is not snapped to the road with which it overlaps.
+
+#### Code Review
+
+The check ensures that the Atlas object being evaluated is an [Area](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Area.java).
+The roads that intersects the area is then verified to be properly snapped to the area. If not, both the area, intersecting edge and any connected edges within the area are marked as 
+flagged.
+
+To learn more about the code, please look at the comments in the source code for the check.
+[PedestrianAreaOverlappingEdgeCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/area/PedestrianAreaOverlappingEdgeCheck.java)

--- a/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
+++ b/docs/checks/pedestrianAreaOverlappingEdgeCheck.md
@@ -14,8 +14,8 @@ this check will flag pedestrian areas overlapping with unsnapped roads along wit
 
 #### Live Examples
 
-1. Line [id:223986287](https://www.openstreetmap.org/way/223986287) is is not snapped to the road with which it overlaps.
-2. Line [id:575511688](https://www.openstreetmap.org/way/575511688) is is not snapped to the road with which it overlaps.
+1. Line [id:223986287](https://www.openstreetmap.org/way/223986287) is not snapped to the road with which it overlaps.
+2. Line [id:575511688](https://www.openstreetmap.org/way/575511688) is not snapped to the road with which it overlaps.
 
 #### Code Review
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -91,19 +91,12 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
             final boolean intersectsAtStart = locationsInSegments.contains(edgeStartLocation);
             // Checks if intersection is at end of the edge
             final boolean intersectsAtEnd = locationsInSegments.contains(edgeEndLocation);
-            // Filter the segments with the intersecting points
-            final Set<Segment> filteredSegments = segments.stream()
-                    .filter(segment -> edgeStartLocation.equals(segment.start())
-                            || edgeStartLocation.equals(segment.end())
-                            || edgeEndLocation.equals(segment.start())
-                            || edgeEndLocation.equals(segment.end()))
-                    .collect(Collectors.toSet());
             // If both ends of the edge intersects the area, check if it is properly snapped by
             // checking if both the intersecting points are on the same segment.
             // If none of the filtered segments have both the start and end nodes, then add the
             // edge and all its connected edges that are within the area to flag them.
             if ((intersectsAtStart && intersectsAtEnd && this
-                    .isNotSnappedToSegments(filteredSegments, edgeStartLocation, edgeEndLocation))
+                    .isNotSnappedToSegments(segments, edgeStartLocation, edgeEndLocation))
                     ||
                     // If any one of the end of the connected edge is fully enclosed within the
                     // area, flag the edge and all its connected edges that are within the area.
@@ -166,7 +159,7 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
      *            any location
      * @return true if none of the segments have both the locations in it.
      */
-    private boolean isNotSnappedToSegments(final Set<Segment> segments, final Location locationOne,
+    private boolean isNotSnappedToSegments(final List<Segment> segments, final Location locationOne,
             final Location locationTwo)
     {
         return segments.stream().noneMatch(segment -> (locationOne.equals(segment.start())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -73,16 +73,16 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Area area = (Area) object;
+        final Polygon areaPolygon = area.asPolygon();
         // All segments of the area
-        final List<Segment> segments = area.asPolygon().segments();
+        final List<Segment> segments = areaPolygon.segments();
         // Get all start and end locations of all segments in the area
         final List<Location> locationsInSegments = Segment.asList(segments);
         // Filter and collect all valid intersecting edges
         final Set<Edge> filteredIntersectingEdges = Iterables
-                .stream(area.getAtlas().edgesIntersecting(area.asPolygon()))
+                .stream(area.getAtlas().edgesIntersecting(areaPolygon))
                 .filter(edge -> this.isValidIntersectingEdge(edge, area)).collectToSet();
         final Set<AtlasObject> overlappingEdges = new HashSet<>();
-        final Polygon areaPolygon = area.asPolygon();
         for (final Edge edge : filteredIntersectingEdges)
         {
             final Location edgeStartLocation = edge.start().getLocation();
@@ -99,16 +99,14 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
                             || edgeEndLocation.equals(segment.end()))
                     .collect(Collectors.toSet());
             // If both ends of the edge intersects the area, check if it is properly snapped by
-            // checking
-            // if both the intersecting points are on the same segment.
+            // checking if both the intersecting points are on the same segment.
             // If none of the filtered segments have both the start and end nodes, then add the
             // edge and all its connected edges that are within the area to flag them.
             if ((intersectsAtStart && intersectsAtEnd && this
                     .isNotSnappedToSegments(filteredSegments, edgeStartLocation, edgeEndLocation))
                     ||
                     // If any one of the end of the connected edge is fully enclosed within the
-                    // area,
-                    // flag the edge and all its connected edges that are within the area.
+                    // area, flag the edge and all its connected edges that are within the area.
                     (intersectsAtStart && !intersectsAtEnd
                             && areaPolygon.fullyGeometricallyEncloses(edgeEndLocation))
                     || (intersectsAtEnd && !intersectsAtStart

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -43,8 +43,8 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
 {
     private static final long serialVersionUID = 1861527706740836635L;
-    private static final List<String> FALLBACK_INSTRUCTIONS = Collections
-            .singletonList("Pedestrian area {0,number,#} is overlapping way id(s) {1}.");
+    private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
+            "Pedestrian area {0,number,#} is overlapping way id(s) {1} and is not snapped at all points of intersections.");
     private static final Predicate<Distance> DISTANCE_GREATER_THAN_ONE_METER = distance -> distance
             .isGreaterThanOrEqualTo(Distance.ONE_METER);
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -21,7 +21,6 @@ import org.openstreetmap.atlas.tags.FootTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
 import org.openstreetmap.atlas.tags.LevelTag;
-import org.openstreetmap.atlas.tags.LocationTag;
 import org.openstreetmap.atlas.tags.ServiceTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -33,10 +32,10 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
  * This check flags pedestrian areas that are not properly snapped to its valid
  * intersecting/overlapping edges. A pedestrian area is an {@link Area} with {@link HighwayTag} =
  * "pedestrian" tag. Valid intersecting edges are edges with the same elevation(same
- * {@link LayerTag}, {@link LocationTag}, {@link LevelTag}) as the area, and highway tag value not
- * equal to foot way, pedestrian, steps and path. The pedestrian area and any valid intersecting/
- * overlapping edge that is not snapped to the area are flagged along with its connected edges that
- * are within the pedestrian area.
+ * {@link LayerTag}, {@link LevelTag}) as the area, and highway tag value not equal to foot way,
+ * pedestrian, steps and path. The pedestrian area and any valid intersecting/ overlapping edge that
+ * is not snapped to the area are flagged along with its connected edges that are within the
+ * pedestrian area.
  *
  * @author sayas01
  */
@@ -47,6 +46,8 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
             "Pedestrian area {0,number,#} is overlapping way id(s) {1} and is not snapped at all points of intersections.");
     private static final Predicate<Distance> DISTANCE_GREATER_THAN_ONE_METER = distance -> distance
             .isGreaterThanOrEqualTo(Distance.ONE_METER);
+    private static final String ZERO = "0";
+    private static final Long ZERO_LONG = 0L;
 
     /**
      * Default constructor
@@ -187,15 +188,14 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
      *            any given edge
      * @param area
      *            any given area
-     * @return true if the edge and area have the same Layer and Location tag values
+     * @return true if the edge and area have the same Layer and Level tag values
      */
     private boolean isOfSameElevation(final Edge edge, final Area area)
     {
-        return area.getTag(LayerTag.KEY).orElse("").equals(edge.getTag(LayerTag.KEY).orElse(""))
-                && area.getTag(LocationTag.KEY).orElse("")
-                        .equals(edge.getTag(LocationTag.KEY).orElse(""))
-                && area.getTag(LevelTag.KEY).orElse("")
-                        .equals(edge.getTag(LevelTag.KEY).orElse(""));
+        return LevelTag.getTaggedOrImpliedValue(area, ZERO)
+                .equals(LevelTag.getTaggedOrImpliedValue(edge, ZERO))
+                && LayerTag.getTaggedOrImpliedValue(area, ZERO_LONG)
+                        .equals(LayerTag.getTaggedOrImpliedValue(edge, ZERO_LONG));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -31,10 +30,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * This check flags pedestrian areas that are not properly snapped to its valid
  * intersecting/overlapping edges. A pedestrian area is an {@link Area} with {@link HighwayTag} =
  * "pedestrian" tag. Valid intersecting edges are edges with the same elevation(same
- * {@link LayerTag}, {@link LocationTag}) as the area, and highway tag value not equal to foot way,
- * pedestrian, steps and path. The pedestrian area and any valid intersecting/ overlapping edge that
- * is not snapped to the area are flagged along with its connected edges that are within the
- * pedestrian area.
+ * {@link LayerTag}, {@link LocationTag}, {@link LevelTag}) as the area, and highway tag value not
+ * equal to foot way, pedestrian, steps and path. The pedestrian area and any valid intersecting/
+ * overlapping edge that is not snapped to the area are flagged along with its connected edges that
+ * are within the pedestrian area.
  *
  * @author sayas01
  */
@@ -95,12 +94,11 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
             // checking if both the intersecting points are on the same segment.
             // If none of the filtered segments have both the start and end nodes, then add the
             // edge and all its connected edges that are within the area to flag them.
-            if ((intersectsAtStart && intersectsAtEnd && this
-                    .isNotSnappedToSegments(segments, edgeStartLocation, edgeEndLocation))
-                    ||
+            if ((intersectsAtStart && intersectsAtEnd
+                    && this.isNotSnappedToSegments(segments, edgeStartLocation, edgeEndLocation))
                     // If any one of the end of the connected edge is fully enclosed within the
                     // area, flag the edge and all its connected edges that are within the area.
-                    (intersectsAtStart && !intersectsAtEnd
+                    || (intersectsAtStart && !intersectsAtEnd
                             && areaPolygon.fullyGeometricallyEncloses(edgeEndLocation))
                     || (intersectsAtEnd && !intersectsAtStart
                             && areaPolygon.fullyGeometricallyEncloses(edgeStartLocation)))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -39,6 +39,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
 {
+    private static final long serialVersionUID = 1861527706740836635L;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList("Pedestrian area {0,number,#} is overlapping way id(s) {1}.");
 
@@ -218,10 +219,11 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
                 && (HighwayTag.isCarNavigableHighway(edge)
                         // or a cycleway with no foot access
                         || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.CYCLEWAY)
-                                && Validators.isNotOfType(edge, FootTag.class, FootTag.NO))
+                                && Validators.isOfType(edge, FootTag.class, FootTag.NO))
                         // or a service road that is not a yard, siding, spur or crossover
-                        || Validators.isNotOfType(edge, ServiceTag.class, ServiceTag.YARD,
-                                ServiceTag.SIDING, ServiceTag.SPUR, ServiceTag.CROSSOVER))
+                        || Validators.isOfType(edge, ServiceTag.class, ServiceTag.ALLEY,
+                                ServiceTag.PARKING_AISLE, ServiceTag.DRIVEWAY,
+                                ServiceTag.EMERGENCY_ACCESS, ServiceTag.DRIVE_THROUGH))
                 // and should have the same layer or level tag if any, as the area
                 && this.isOfSameElevation(edge, area);
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -25,7 +25,15 @@ import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * @author sayana_saithu
+ * This check flags pedestrian areas that are not properly snapped to its valid
+ * intersecting/overlapping edges. A pedestrian area is an {@link Area} with {@link HighwayTag} =
+ * "pedestrian" tag. Valid intersecting edges are edges with the same elevation(same
+ * {@link LayerTag}, {@link LocationTag}) as the area, and highway tag value not equal to foot way,
+ * pedestrian, steps and path. The pedestrian area and any valid intersecting/ overlapping edge that
+ * is not snapped to the area are flagged along with its connected edges that are within the
+ * pedestrian area.
+ *
+ * @author sayas01
  */
 public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
 {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -220,7 +220,8 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
                         // or a cycleway with no foot access
                         || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.CYCLEWAY)
                                 && Validators.isOfType(edge, FootTag.class, FootTag.NO))
-                        // or a service road that is not a yard, siding, spur or crossover
+                        // or a service road that is an alley, parking aisle, driveway, emergency
+                        // access or drive through
                         || Validators.isOfType(edge, ServiceTag.class, ServiceTag.ALLEY,
                                 ServiceTag.PARKING_AISLE, ServiceTag.DRIVEWAY,
                                 ServiceTag.EMERGENCY_ACCESS, ServiceTag.DRIVE_THROUGH))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/PedestrianAreaOverlappingEdgeCheck.java
@@ -1,0 +1,168 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Segment;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.AreaTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.LocationTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author sayana_saithu
+ */
+public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
+{
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "Pedestrian area {0,number,#} is overlapping way id(s) {1}.");
+    /**
+     * Default constructor
+     *
+     * @param configuration {@link Configuration} required to construct any Check
+     */
+    public PedestrianAreaOverlappingEdgeCheck(
+            Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * Checks to see whether the supplied object class type is valid for this particular check
+     *
+     * @param object The {@link AtlasObject} you are checking
+     * @return true if it is
+     */
+    @Override public boolean validCheckForObject(AtlasObject object)
+    {
+        return object instanceof Area && this.isPedestrianArea(object) && !isFlagged(object.getOsmIdentifier());
+    }
+
+    @Override protected Optional<CheckFlag> flag(AtlasObject object)
+    {
+        final Area area = (Area) object;
+
+        // All segments of the area
+        final List<Segment> segments = area.asPolygon().segments();
+        final Set<Location> locationsInSegments = new HashSet<>();
+        segments.stream().forEach(segment-> {
+            locationsInSegments.add(segment.start());
+            locationsInSegments.add(segment.end());});
+        // Valid intersecting edges
+        final Set<Edge> filteredIntersectingEdges = Iterables
+                .stream(area.getAtlas().edgesIntersecting(area.asPolygon()))
+                .filter(edge -> this.isValidIntersectingEdge(edge, area)).collectToSet();
+
+        Set<AtlasObject> overlappingEdges = new HashSet<>();
+        final Polygon areaPolygon = area.asPolygon();
+        for(Edge edge: filteredIntersectingEdges)
+        {
+            final Location edgeStartLocation = edge.start().getLocation();
+            final Location edgeEndLocation = edge.end().getLocation();
+            // Intersecting points of the edge
+            //final Set<Location> allIntersectingPoints = area.asPolygon().intersections(edge.asPolyLine());
+            // Intersects at start node
+            final boolean intersectsAtStart = locationsInSegments.contains(edgeStartLocation);
+            // Intersects at end node
+            final boolean intersectsAtEnd = locationsInSegments.contains(edgeEndLocation);
+
+            // Filtered segments based on intersection points
+            final Set<Segment> filteredSegments = segments.stream()
+                    .filter(segment -> edgeStartLocation.equals(segment.start())||edgeStartLocation.equals(segment.end())
+                                    || edgeEndLocation.equals(segment.start())|| edgeEndLocation.equals(segment.end())
+                            //                            allIntersectingPoints.contains(segment.start())
+                            //                            || allIntersectingPoints.contains(segment.end())
+                    )
+                    .collect(Collectors.toSet());
+
+
+            // If both ends of the edge intersects the area
+            if(intersectsAtStart && intersectsAtEnd)
+            {
+                // If non eof the segments have both the start and end nodes
+                if(filteredSegments.stream().noneMatch(segment ->
+                        (edgeStartLocation.equals(segment.start())  ||
+                                edgeStartLocation.equals(segment.end()))
+                                && (edgeEndLocation.equals(segment.start()) || edgeEndLocation.equals(segment
+                                .end()) )))
+                {
+                    edge.connectedEdges().stream().filter(connectedEdge-> connectedEdge.isMasterEdge() &&
+                            areaPolygon.fullyGeometricallyEncloses(connectedEdge.asPolyLine())).forEach(
+                            overlappingEdges::add);
+                    overlappingEdges.add(edge);
+                }
+            }
+
+            else if( (intersectsAtStart && areaPolygon
+                    .fullyGeometricallyEncloses(edgeEndLocation)) || (!intersectsAtStart && intersectsAtEnd &&areaPolygon.
+                    fullyGeometricallyEncloses(edgeStartLocation)))
+            {
+                edge.connectedEdges().stream().filter(connectedEdge-> connectedEdge.isMasterEdge() &&
+                        areaPolygon.fullyGeometricallyEncloses(connectedEdge.asPolyLine())).forEach(
+                        overlappingEdges::add);
+                overlappingEdges.add(edge);
+            }
+        }
+        if(!overlappingEdges.isEmpty())
+        {
+
+            this.markAsFlagged(object.getOsmIdentifier());
+            final CheckFlag flag = this.createFlag(overlappingEdges,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier(),
+                            new StringList(getIdentifiers(overlappingEdges)).join(", ")));
+            flag.addObject(object);
+            return Optional.of(flag);
+        }
+        return Optional.empty();
+    }
+
+
+    private Iterable<String> getIdentifiers(final Set<AtlasObject> objects)
+    {
+        return Iterables.stream(objects).map(AtlasObject::getIdentifier).map(String::valueOf)
+                .collectToList();
+    }
+
+    /**
+     *
+     * @param intersectingEdge
+     * @param area
+     * @return
+     */
+    private boolean isValidIntersectingEdge(final Edge intersectingEdge, final Area area)
+    {
+        return
+                intersectingEdge.getOsmIdentifier()!=area.getOsmIdentifier() && intersectingEdge.isMasterEdge() && Validators.hasValuesFor(intersectingEdge,HighwayTag.class) &&
+                        Validators.isNotOfType(intersectingEdge,HighwayTag.class,HighwayTag.FOOTWAY,HighwayTag.PATH) && !isPedestrianArea(intersectingEdge) &&
+                        area.getTag(LayerTag.KEY).orElse("").equals(intersectingEdge.getTag(LayerTag.KEY).orElse("")) && area.getTag(
+                        LocationTag.KEY).orElse("").equals(intersectingEdge.getTag(LocationTag.KEY).orElse(""));
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+
+    private boolean isPedestrianArea(final AtlasObject object)
+    {
+        return Validators.isOfType(object,
+                AreaTag.class, AreaTag.YES) && Validators.isOfType(object, HighwayTag.class, HighwayTag.PEDESTRIAN);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
@@ -1,0 +1,55 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Unit tests for {@link PedestrianAreaOverlappingEdgeCheck}
+ *
+ * @author sayas01
+ */
+public class PedestrianAreaOverlappingEdgeCheckTest
+{
+    @Rule
+    public PedestrianAreaOverlappingEdgeCheckTestRule setup = new PedestrianAreaOverlappingEdgeCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testCorrectlySnappedEdge()
+    {
+        this.verifier.actual(this.setup.getCorrectlySnappedAtlas(),
+                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testInCorrectlySnappedEdge()
+    {
+        this.verifier.actual(this.setup.getInCorrectlySnappedAtlas(),
+                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testIntersectingEdgeEndingInsideArea()
+    {
+        this.verifier.actual(this.setup.getIntersectingEdgeEndingInsideArea(),
+                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testEdgesWithDifferentElevation()
+    {
+        this.verifier.actual(this.setup.getEdgesWithDifferentElevation(),
+                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
@@ -41,7 +41,7 @@ public class PedestrianAreaOverlappingEdgeCheckTest
         this.verifier.actual(this.setup.getInCorrectlySnappedAtlas(),
                 new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTest.java
@@ -28,6 +28,14 @@ public class PedestrianAreaOverlappingEdgeCheckTest
     }
 
     @Test
+    public void testEdgesWithDifferentElevation()
+    {
+        this.verifier.actual(this.setup.getEdgesWithDifferentElevation(),
+                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testInCorrectlySnappedEdge()
     {
         this.verifier.actual(this.setup.getInCorrectlySnappedAtlas(),
@@ -43,13 +51,5 @@ public class PedestrianAreaOverlappingEdgeCheckTest
                 new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyExpectedSize(1);
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
-    }
-
-    @Test
-    public void testEdgesWithDifferentElevation()
-    {
-        this.verifier.actual(this.setup.getEdgesWithDifferentElevation(),
-                new PedestrianAreaOverlappingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
@@ -152,6 +152,11 @@ public class PedestrianAreaOverlappingEdgeCheckTestRule extends CoreTestRule
         return this.correctlySnappedAtlas;
     }
 
+    public Atlas getEdgesWithDifferentElevation()
+    {
+        return this.edgesWithDifferentElevation;
+    }
+
     public Atlas getInCorrectlySnappedAtlas()
     {
         return this.inCorrectlySnappedAtlas;
@@ -160,10 +165,5 @@ public class PedestrianAreaOverlappingEdgeCheckTestRule extends CoreTestRule
     public Atlas getIntersectingEdgeEndingInsideArea()
     {
         return this.intersectingEdgeEndingInsideArea;
-    }
-
-    public Atlas getEdgesWithDifferentElevation()
-    {
-        return this.edgesWithDifferentElevation;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
@@ -1,0 +1,168 @@
+package org.openstreetmap.atlas.checks.validation.areas;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Test data for {@link PedestrianAreaOverlappingEdgeCheckTest}
+ *
+ * @author sayas01
+ */
+public class PedestrianAreaOverlappingEdgeCheckTestRule extends CoreTestRule
+{
+    private static final String AREA_LOC_1 = "34.0619736, -4.9729771";
+    private static final String AREA_LOC_2 = "34.0619558, -4.9729228";
+    private static final String AREA_LOC_3 = "34.0619157, -4.9728423";
+    private static final String AREA_LOC_4 = "34.0622502, -4.9725721";
+    private static final String AREA_LOC_5 = "34.0623169, -4.9726083";
+    private static final String AREA_LOC_6 = "34.0623146, -4.9727816";
+    private static final String AREA_LOC_7 = "34.0623136, -4.9729020";
+
+    private static final String LOC_1_WITHIN_AREA = "34.0620432, -4.9728769";
+    private static final String LOC_2_WITHIN_AREA = "34.0621669, -4.9728356";
+    private static final String LOC_OUTSIDE_AREA = "34.0618719, -4.9729555";
+
+    @TestAtlas(
+            nodes = {
+                    // nodes
+                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+            },
+            // areas
+            areas = {
+                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
+                            tags = { "area=yes", "highway=pedestrian" })},
+            edges ={
+                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
+                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
+                    @Edge(id = "2000000001", coordinates = {
+                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3)}, tags = {"highway=residential"}),
+
+            })
+    private Atlas correctlySnappedAtlas;
+
+    @TestAtlas(
+            nodes = {
+                    // nodes
+                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
+            },
+            // areas
+            areas = {
+                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
+                            tags = { "area=yes", "highway=pedestrian" })},
+            edges ={
+                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
+                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
+                    @Edge(id = "2000000001", coordinates = {
+                            @Loc(value = AREA_LOC_2),
+                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential"}),
+                    @Edge(id = "2500000001", coordinates = {
+                            @Loc(value = LOC_1_WITHIN_AREA),
+                            @Loc(value = LOC_2_WITHIN_AREA) }, tags = {"highway=residential"}),
+                    @Edge(id = "2400000001", coordinates = {
+                            @Loc(value = LOC_2_WITHIN_AREA), @Loc(value = AREA_LOC_6)}, tags = {"highway=residential"})
+            })
+    private Atlas inCorrectlySnappedAtlas;
+
+    @TestAtlas(
+            nodes = {
+                    // nodes
+                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
+            },
+            // areas
+            areas = {
+                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
+                            tags = { "area=yes", "highway=pedestrian" })},
+            edges ={
+                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
+                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
+                    @Edge(id = "2000000001", coordinates = {
+                            @Loc(value = AREA_LOC_2),
+                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential"})
+            })
+    private Atlas intersectingEdgeEndingInsideArea;
+
+    @TestAtlas(
+            nodes = {
+                    // nodes
+                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
+            },
+            // areas
+            areas = {
+                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
+                            tags = { "area=yes", "highway=pedestrian" })},
+            edges ={
+                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
+                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
+                    @Edge(id = "2000000001", coordinates = {
+                            @Loc(value = AREA_LOC_2),
+                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential","layer=2"})
+            })
+    private Atlas edgesWithDifferentElevation;
+
+    public Atlas getCorrectlySnappedAtlas()
+    {
+        return this.correctlySnappedAtlas;
+    }
+
+    public Atlas getInCorrectlySnappedAtlas()
+    {
+        return this.inCorrectlySnappedAtlas;
+    }
+
+    public Atlas getIntersectingEdgeEndingInsideArea()
+    {
+        return this.intersectingEdgeEndingInsideArea;
+    }
+
+    public Atlas getEdgesWithDifferentElevation()
+    {
+        return this.edgesWithDifferentElevation;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
@@ -80,7 +80,7 @@ public class PedestrianAreaOverlappingEdgeCheckTestRule extends CoreTestRule
                                     @Edge(id = "2000000001", coordinates = {
                                             @Loc(value = AREA_LOC_2),
                                             @Loc(value = LOC_1_WITHIN_AREA) }, tags = {
-                                                    "highway=residential" }),
+                                                    "highway=cycleway", "foot=yes" }),
                                     @Edge(id = "2500000001", coordinates = {
                                             @Loc(value = LOC_1_WITHIN_AREA),
                                             @Loc(value = LOC_2_WITHIN_AREA) }, tags = {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheckTestRule.java
@@ -27,123 +27,124 @@ public class PedestrianAreaOverlappingEdgeCheckTestRule extends CoreTestRule
     private static final String LOC_2_WITHIN_AREA = "34.0621669, -4.9728356";
     private static final String LOC_OUTSIDE_AREA = "34.0618719, -4.9729555";
 
-    @TestAtlas(
-            nodes = {
-                    // nodes
-                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
-                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
-                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
-                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
-                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
-                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
-                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
-                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
-            },
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+            @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+            @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+            @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+            @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+            @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+            @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+            @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)), },
             // areas
-            areas = {
-                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
-                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
-                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
-                            tags = { "area=yes", "highway=pedestrian" })},
-            edges ={
-                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
-                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
-                    @Edge(id = "2000000001", coordinates = {
-                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3)}, tags = {"highway=residential"}),
+            areas = { @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                    @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                    @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6),
+                    @Loc(value = AREA_LOC_7) }, tags = { "area=yes",
+                            "highway=pedestrian" }) }, edges = {
+                                    @Edge(id = "2300000001", coordinates = {
+                                            @Loc(value = LOC_OUTSIDE_AREA),
+                                            @Loc(value = AREA_LOC_2) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2000000001", coordinates = {
+                                            @Loc(value = AREA_LOC_2),
+                                            @Loc(value = AREA_LOC_3) }, tags = {
+                                                    "highway=residential" }),
 
             })
     private Atlas correctlySnappedAtlas;
 
-    @TestAtlas(
-            nodes = {
-                    // nodes
-                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
-                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
-                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
-                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
-                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
-                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
-                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
-                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
-                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
-                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
-            },
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+            @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+            @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+            @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+            @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+            @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+            @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+            @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+            @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+            @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA)) },
             // areas
-            areas = {
-                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
-                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
-                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
-                            tags = { "area=yes", "highway=pedestrian" })},
-            edges ={
-                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
-                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
-                    @Edge(id = "2000000001", coordinates = {
-                            @Loc(value = AREA_LOC_2),
-                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential"}),
-                    @Edge(id = "2500000001", coordinates = {
-                            @Loc(value = LOC_1_WITHIN_AREA),
-                            @Loc(value = LOC_2_WITHIN_AREA) }, tags = {"highway=residential"}),
-                    @Edge(id = "2400000001", coordinates = {
-                            @Loc(value = LOC_2_WITHIN_AREA), @Loc(value = AREA_LOC_6)}, tags = {"highway=residential"})
-            })
+            areas = { @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                    @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                    @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6),
+                    @Loc(value = AREA_LOC_7) }, tags = { "area=yes",
+                            "highway=pedestrian" }) }, edges = {
+                                    @Edge(id = "2300000001", coordinates = {
+                                            @Loc(value = LOC_OUTSIDE_AREA),
+                                            @Loc(value = AREA_LOC_2) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2000000001", coordinates = {
+                                            @Loc(value = AREA_LOC_2),
+                                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2500000001", coordinates = {
+                                            @Loc(value = LOC_1_WITHIN_AREA),
+                                            @Loc(value = LOC_2_WITHIN_AREA) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2400000001", coordinates = {
+                                            @Loc(value = LOC_2_WITHIN_AREA),
+                                            @Loc(value = AREA_LOC_6) }, tags = {
+                                                    "highway=residential" }) })
     private Atlas inCorrectlySnappedAtlas;
 
-    @TestAtlas(
-            nodes = {
-                    // nodes
-                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
-                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
-                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
-                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
-                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
-                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
-                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
-                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
-                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
-                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
-            },
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+            @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+            @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+            @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+            @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+            @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+            @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+            @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+            @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+            @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA)) },
             // areas
-            areas = {
-                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
-                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
-                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
-                            tags = { "area=yes", "highway=pedestrian" })},
-            edges ={
-                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
-                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
-                    @Edge(id = "2000000001", coordinates = {
-                            @Loc(value = AREA_LOC_2),
-                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential"})
-            })
+            areas = { @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                    @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                    @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6),
+                    @Loc(value = AREA_LOC_7) }, tags = { "area=yes",
+                            "highway=pedestrian" }) }, edges = {
+                                    @Edge(id = "2300000001", coordinates = {
+                                            @Loc(value = LOC_OUTSIDE_AREA),
+                                            @Loc(value = AREA_LOC_2) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2000000001", coordinates = {
+                                            @Loc(value = AREA_LOC_2),
+                                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {
+                                                    "highway=residential" }) })
     private Atlas intersectingEdgeEndingInsideArea;
 
-    @TestAtlas(
-            nodes = {
-                    // nodes
-                    @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
-                    @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
-                    @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
-                    @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
-                    @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
-                    @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
-                    @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
-                    @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
-                    @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
-                    @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA))
-            },
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "3000000001", coordinates = @Loc(value = AREA_LOC_1)),
+            @Node(id = "4000000001", coordinates = @Loc(value = AREA_LOC_2)),
+            @Node(id = "5000000001", coordinates = @Loc(value = AREA_LOC_3)),
+            @Node(id = "6000000001", coordinates = @Loc(value = AREA_LOC_4)),
+            @Node(id = "7000000001", coordinates = @Loc(value = AREA_LOC_5)),
+            @Node(id = "8000000001", coordinates = @Loc(value = AREA_LOC_6)),
+            @Node(id = "9000000001", coordinates = @Loc(value = AREA_LOC_7)),
+            @Node(id = "1000000001", coordinates = @Loc(value = LOC_OUTSIDE_AREA)),
+            @Node(id = "9100000001", coordinates = @Loc(value = LOC_1_WITHIN_AREA)),
+            @Node(id = "1200000001", coordinates = @Loc(value = LOC_2_WITHIN_AREA)) },
             // areas
-            areas = {
-                    @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
-                            @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
-                            @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6), @Loc(value = AREA_LOC_7) },
-                            tags = { "area=yes", "highway=pedestrian" })},
-            edges ={
-                    @Edge(id = "2300000001", coordinates = {@Loc(value = LOC_OUTSIDE_AREA),
-                            @Loc(value = AREA_LOC_2)}, tags = {"highway=residential"}),
-                    @Edge(id = "2000000001", coordinates = {
-                            @Loc(value = AREA_LOC_2),
-                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {"highway=residential","layer=2"})
-            })
+            areas = { @Area(id = "1000000001", coordinates = { @Loc(value = AREA_LOC_1),
+                    @Loc(value = AREA_LOC_2), @Loc(value = AREA_LOC_3), @Loc(value = AREA_LOC_4),
+                    @Loc(value = AREA_LOC_5), @Loc(value = AREA_LOC_6),
+                    @Loc(value = AREA_LOC_7) }, tags = { "area=yes",
+                            "highway=pedestrian" }) }, edges = {
+                                    @Edge(id = "2300000001", coordinates = {
+                                            @Loc(value = LOC_OUTSIDE_AREA),
+                                            @Loc(value = AREA_LOC_2) }, tags = {
+                                                    "highway=residential" }),
+                                    @Edge(id = "2000000001", coordinates = {
+                                            @Loc(value = AREA_LOC_2),
+                                            @Loc(value = LOC_1_WITHIN_AREA) }, tags = {
+                                                    "highway=residential", "layer=2" }) })
     private Atlas edgesWithDifferentElevation;
 
     public Atlas getCorrectlySnappedAtlas()


### PR DESCRIPTION
### Description:

The purpose of this check is to flag pedestrian areas that are not properly snapped to its overlapping edges. Pedestrian areas are defined as Ways with highway=PEDESTRIAN and area=YES tags. Overlapping roads are Edges with any highway=** except highway=path, highway=steps, highway=footway, and highway=pedestrian tag with the same elevation (same LevelTag and LayerTag) as the pedestrian area. If the overlapping edge is not properly snapped to the pedestrian area, then, the area, the overlapping edge and all its connected edges that are within the area are marked as flagged.

### Potential Impact:

None

### Unit Test Approach:

Unit tests have been added to test the functionality.

### Test Results:

All tests passing.

